### PR TITLE
Feature/mesos 0.17

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# InteliJ IDEA
+atlassian-ide-plugin.xml
+.idea/
+
 # Eclipse
 .classpath
 .project

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <version>${cassandra.version}-${cassandra-mesos.version}</version>
 
     <properties>
-        <mesos-utils.version>0.0.6</mesos-utils.version>
+        <mesos-utils.version>0.0.7</mesos-utils.version>
 
         <!-- Cassandra Mesos version. Looks like a build number from Maven's perspective-->
         <cassandra-mesos.version>2</cassandra-mesos.version>


### PR DESCRIPTION
- Enabled Mesos 0.17.0 support.
- Bumped `mesos-utils` version to `0.0.7`. Please review and merge https://github.com/mesosphere/mesos-utils/pull/2 before merging this in.
- Removed Scala 2.10.0 dependency brought in by `org.scalatest` with exclusion rule.
