### PR TITLE
fix clusterName substitution

### DIFF
--- a/src/main/scala/mesosphere/cassandra/ConfigServer.scala
+++ b/src/main/scala/mesosphere/cassandra/ConfigServer.scala
@@ -35,10 +35,8 @@ class ConfigServer(port: Int, cassConfigDir: String, seedNodes: mutable.Set[Stri
 
       val substitutedContent = fileContent.map {
         line =>
-          line.replaceAllLiterally("${seedNodes}", seedNodes
-            .mkString(","))
-            .replaceAllLiterally("${clusterName}", clusterNameSlugged
-            .mkString(","))
+          line.replaceAllLiterally("${seedNodes}", seedNodes.mkString(","))
+            .replaceAllLiterally("${clusterName}", clusterNameSlugged)
       }.mkString("\n")
 
       response.setContentType("application/octet-stream;charset=utf-8")


### PR DESCRIPTION
Currently `clusterName` value replacement result in string with commas

"test-cluster" -> "t,e,s,t,-,c,l,u,s,t,e,r"