### PR TITLE
Fix issues with packaging

### DIFF
--- a/cassandra-executor/src/main/resources/logback.xml
+++ b/cassandra-executor/src/main/resources/logback.xml
@@ -16,11 +16,13 @@
             <maxFileSize>10MB</maxFileSize>
         </triggeringPolicy>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] {%marker} %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 
-    <root level="debug">
+    <logger name="io.mesosphere" level="trace"/>
+
+    <root level="info">
         <appender-ref ref="FILE"/>
     </root>
 </configuration>

--- a/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
+++ b/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
@@ -30,7 +30,7 @@ public final class Main {
 
         final int port0 = Integer.parseInt(portOption.get());
         final String executorFilePath = Env.option("EXECUTOR_FILE_PATH").or(workingDir("/cassandra-executor.jar"));
-        final String jdkTarPath = Env.option("JDK_FILE_PATH").or(workingDir("/jdk.tar.gz"));
+        final String jdkTarPath = Env.option("JDK_FILE_PATH").or(workingDir("/jdk-7u75-linux-x64.tar.gz"));
         final String cassandraTarPath = Env.option("CASSANDRA_FILE_PATH").or(workingDir("/cassandra.tar.gz"));
 
         final int       executorCount           = Integer.parseInt(     Env.option("CASSANDRA_NODE_COUNT").or("3"));

--- a/cassandra-framework/src/main/resources/logback.xml
+++ b/cassandra-framework/src/main/resources/logback.xml
@@ -6,7 +6,7 @@
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
             <!--<pattern>%date %-5.5level [%-20.20thread] %-20.20logger{20} - %message%n%xException{5}</pattern>-->
-            <pattern>%date %-5.5level [%-20.20thread] %-36.36logger{36} - %message%n</pattern>
+            <pattern>%date %-5.5level [%-20.20thread] %-36.36logger{36} - {%marker} %message%n</pattern>
         </encoder>
     </appender>
 
@@ -23,14 +23,16 @@
             <maxFileSize>10MB</maxFileSize>
         </triggeringPolicy>
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger{36} - {%marker} %msg%n</pattern>
         </encoder>
     </appender>
 
     <logger name="org.jboss.logging" level="warn"/>
     <logger name="org.xnio" level="info"/>
 
-    <root level="debug">
+    <logger name="io.mesosphere" level="trace"/>
+
+    <root level="info">
         <!--<appender-ref ref="STDOUT"/>-->
         <appender-ref ref="FILE"/>
     </root>

--- a/marathon.json
+++ b/marathon.json
@@ -5,7 +5,8 @@
   "mem": 512,
   "ports": [0],
   "uris": [
-    "$url"
+    "$url",
+    "https://downloads.mesosphere.io/cassandra-mesos/jdk/jdk-7u75-linux-x64.tar.gz"
   ],
   "env": {
     "MESOS_ZK": "zk://localhost:2181/mesos",
@@ -17,5 +18,5 @@
     "CASSANDRA_RESOURCE_DISK_MB": "2048",
     "CASSANDRA_HEALTH_CHECK_INTERVAL_SECONDS": "60"
   },
-  "cmd": "java $JAVA_OPTS -classpath cassandra-framework.jar io.mesosphere.mesos.frameworks.cassandra.Main"
+  "cmd": "$(pwd)/jdk*/bin/java $JAVA_OPTS -classpath cassandra-framework.jar io.mesosphere.mesos.frameworks.cassandra.Main"
 }

--- a/package.bash
+++ b/package.bash
@@ -4,7 +4,6 @@ set -o errexit -o nounset -o pipefail
 PROJECT_DIR=$(pwd)
 TARGET_DIR="target/framework-package"
 
-DOWNLOAD_URL_JDK="https://downloads.mesosphere.io/cassandra-mesos/jdk/jdk-7u75-linux-x64.tar.gz"
 DOWNLOAD_URL_CASS="https://downloads.mesosphere.io/cassandra-mesos/cassandra/apache-cassandra-2.1.2-bin.tar.gz"
 
 VERSION=${VERSION:-"dev"}
@@ -36,8 +35,8 @@ function preparePackage {(
 
     download
 
-    cp ${PROJECT_DIR}/cassandra-framework/target/cassandra-framework-*-jar-with-dependencies.jar cassandra-framework.jar
-    cp ${PROJECT_DIR}/cassandra-executor/target/cassandra-executor-*-jar-with-dependencies.jar cassandra-executor.jar
+    cp ${PROJECT_DIR}/cassandra-framework/target/cassandra-framework-*-jar-with-dependencies.jar ${TARGET_DIR}/cassandra-framework.jar
+    cp ${PROJECT_DIR}/cassandra-executor/target/cassandra-executor-*-jar-with-dependencies.jar ${TARGET_DIR}/cassandra-executor.jar
 )}
 
 function package {(

--- a/package.bash
+++ b/package.bash
@@ -28,7 +28,6 @@ function download {(
 
     mkdir -p ${TARGET_DIR}
     cd ${TARGET_DIR}
-    _download ${DOWNLOAD_URL_JDK} "jdk.tar.gz"
     _download ${DOWNLOAD_URL_CASS} "cassandra.tar.gz"
 
 )}
@@ -60,7 +59,7 @@ function deploy {(
     aws s3 cp ${PROJECT_DIR}/${TARGET_DIR}/${PACKAGE_TAR} ${S3_DEPLOY_BUCKET}/${PACKAGE_TAR}
 
     info "Generating marathon.json"
-    cat ${PROJECT_DIR}/marathon.json | jq ".uris |= [\"${HTTPS_DEPLOY_BUCKET}/${PACKAGE_TAR}\"]" > ${TARGET_DIR}/marathon.json
+    cat ${PROJECT_DIR}/marathon.json | jq ".uris[0] |= \"${HTTPS_DEPLOY_BUCKET}/${PACKAGE_TAR}\"" > ${TARGET_DIR}/marathon.json
     info "marathon.json written ${PROJECT_DIR}/${TARGET_DIR}/marathon.json"
 
 )}


### PR DESCRIPTION
Update packaging to provide jdk for running the framework in addition to the executors and cassandra servers.