### PR TITLE
Cassandra memory calculation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -94,6 +94,39 @@ The Cassandra Mesos Framework requires an install of Maven between 3.2.1 and 3.2
 
 _NOTE: Maven 3.2.5 has a binary incompatible change with earlier version of Maven 3.2.x and will cause an exception to be thrown when the protobuf tool chain tries to run._
 
+## Cassandra memory usage
+
+Memory used by Cassandra can be roughly categorized into:
+
+* Java heap memory. The amount of memory used by the Java VM for heap memory.
+* Off heap memory. Off heap is used for several reasons by Cassandra:
+     * **index-summary** (default: 5% of the heap size)
+       configured in `cassandra.yaml` - see `index_summary_capacity_in_mb`
+       default to 5% of the heap size (may exceed)
+     * **key-cache** (default: 5% of the heap size)
+       configured in `cassandra.yaml` - see `key_cache_size_in_mb`
+       default to 5% of the heap size
+     * **row-cache** (default: off)
+       configured in `cassandra.yaml` - see `row_cache_size_in_mb` (must be explicitly enabled in taskEnv)
+       default to 0
+     * **counter-cache** (default: min(2.5% of Heap (in MB), 50MB))
+       configured in `cassandra.yaml` - see `counter_cache_size_in_mb`
+       default: min(2.5% of Heap (in MB), 50MB) ; 0 means no cache
+     * **memtables** (default on-heap)
+       configured in `cassandra.yaml` - see `file_cache_size_in_mb`
+       default to the smaller of 1/4 of heap or 512MB
+     * **file-cache** (default: min(25% of Heap (in MB), 512MB))
+       configured in `cassandra.yaml` - see `file_cache_size_in_mb`
+       default to the smaller of 1/4 of heap or 512MB
+     * overhead during flushes/compactions/cleanup
+       implicitly defined by workload
+* OS buffer cache. The amount of (provisioned) memory reserved for the operating system for disk block buffers.
+
+The default configuration simply assumes that you need as much off-heap memory than Java heap memory.
+It basically divides the provisioned amount of memory by 2 and assigns it to the Java heap.
+
+A good planned production system is sized to meet its workload requirements. That does mean proper values for
+Cassandra process environment, `cassandra.yaml` and memory sizing.
 
 ### Setup maven toolchain for protoc
 

--- a/README.markdown
+++ b/README.markdown
@@ -128,6 +128,12 @@ It basically divides the provisioned amount of memory by 2 and assigns it to the
 A good planned production system is sized to meet its workload requirements. That does mean proper values for
 Cassandra process environment, `cassandra.yaml` and memory sizing.
 
+You should not run Cassandra (even in test environments) with less than 4 GB configured in `memMb`.
+A recommended minimum value for `memMb` is 16GB. In times where RAM is getting cheaper, provision as much as you can
+afford - with 8 to 16 GB for `memJavaHeapMb`. Remember to figure out the really required numbers in load and
+stress tests with your application.
+
+
 ### Setup maven toolchain for protoc
 
 1. Download version 2.5.0 of protobuf [here](https://code.google.com/p/protobuf/downloads/list)

--- a/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
+++ b/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
@@ -119,7 +119,6 @@ public final class Main {
             .setNumberOfNodes(executorCount)
             .setNumberOfSeeds(seedCount)
             .setMemMb(resourceMemoryMegabytes);
-        CassandraCluster.fillConfigRoleGaps(defaultConfigRole);
         final PersistedCassandraFrameworkConfiguration configuration = new PersistedCassandraFrameworkConfiguration(
             state,
             frameworkName,

--- a/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
+++ b/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
@@ -112,15 +112,18 @@ public final class Main {
             throw new IllegalArgumentException("number of nodes (" + executorCount + ") and/or number of seeds (" + seedCount + ") invalid");
         }
 
+        CassandraFrameworkProtos.CassandraConfigRole.Builder defaultConfigRole = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+            .setCassandraVersion(cassandraVersion)
+            .setCpuCores(resourceCpuCores)
+            .setDiskMb(resourceDiskMegabytes)
+            .setNumberOfNodes(executorCount)
+            .setNumberOfSeeds(seedCount)
+            .setMemMb(resourceMemoryMegabytes);
+        CassandraCluster.fillConfigRoleGaps(defaultConfigRole);
         final PersistedCassandraFrameworkConfiguration configuration = new PersistedCassandraFrameworkConfiguration(
             state,
             frameworkName,
-            cassandraVersion,
-            executorCount,
-            seedCount,
-            resourceCpuCores,
-            resourceMemoryMegabytes,
-            resourceDiskMegabytes,
+            defaultConfigRole.build(),
             healthCheckIntervalSec,
             bootstrapGraceTimeSec
         );

--- a/cassandra-mesos-model/src/main/java/io/mesosphere/mesos/util/CassandraFrameworkProtosUtils.java
+++ b/cassandra-mesos-model/src/main/java/io/mesosphere/mesos/util/CassandraFrameworkProtosUtils.java
@@ -159,6 +159,29 @@ public final class CassandraFrameworkProtosUtils {
             .transform(cassandraNodeToIp()));
     }
 
+    public static void addTaskEnvEntry(@NotNull final TaskEnv.Builder taskEnv, boolean replace, @NotNull final String name, @NotNull final String value) {
+        for (int i = 0; i < taskEnv.getVariablesList().size(); i++) {
+            TaskEnv.Entry entry = taskEnv.getVariables(i);
+            if (name.equals(entry.getName())) {
+                if (replace)
+                    taskEnv.setVariables(i, TaskEnv.Entry.newBuilder().setName(name).setValue(value).build());
+                return;
+            }
+        }
+        taskEnv.addVariables(TaskEnv.Entry.newBuilder().setName(name).setValue(value).build());
+    }
+
+    public static void setTaskConfig(@NotNull final TaskConfig.Builder taskConfig, @NotNull final TaskConfig.Entry entry) {
+        for (int i = 0; i < taskConfig.getVariablesList().size(); i++) {
+            TaskConfig.Entry e = taskConfig.getVariables(i);
+            if (entry.getName().equals(e.getName())) {
+                taskConfig.setVariables(i, entry);
+                return;
+            }
+        }
+        taskConfig.addVariables(entry);
+    }
+
     private static final class TupleToTaskEnvEntry implements Function<Tuple2<String, String>, TaskEnv.Entry> {
         private static final TupleToTaskEnvEntry INSTANCE = new TupleToTaskEnvEntry();
         @Override

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -24,8 +24,6 @@ message CassandraFrameworkConfiguration {
 
     // default configuration
     required CassandraConfigRole defaultConfigRole = 6;
-    // additional configurations (currently unused)
-    repeated CassandraConfigRole configRoles = 7;
 }
 
 // CassandraConfigRole is currently only used once. But different nodes may require different sizings -

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -46,11 +46,11 @@ message CassandraConfigRole {
     // Cassandra memory usage can be categorized into
     // 1. Java heap (MAX_HEAP_SIZE) - including new-gen (HEAP_NEWSIZE)
     //    Amount of Java heap in MB.
-    //    (defaults to 50% of memMb, if not present)
+    //    (defaults to 50% of memMb, max 16384, if not present)
     optional int64 memJavaHeapMb = 8;
     // 2. Off-Heap
     //    Amount of Off heap in MB.
-    //    (defaults to 50% of memMb, if not present)
+    //    (defaults to memMb - memJavaHeapMb, if not present)
     optional int64 memAssumeOffHeapMb = 9;
     // 3. OS (add as much as possible for OS block cache)
     //    This is just the difference between memMb and memJavaHeapMb + memAssumeOffHeapMb

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -47,11 +47,11 @@ message CassandraConfigRole {
 
     // Cassandra memory usage can be categorized into
     // 1. Java heap (MAX_HEAP_SIZE) - including new-gen (HEAP_NEWSIZE)
-    //    amount of Java heap in MB
+    //    Amount of Java heap in MB.
     //    (defaults to 50% of memMb, if not present)
     optional int64 memJavaHeapMb = 8;
-    // 2. Off-Heap (roughly 50% of Java heap)
-    //    amount of Off heap in MB
+    // 2. Off-Heap
+    //    Amount of Off heap in MB.
     //    (defaults to 50% of memMb, if not present)
     optional int64 memAssumeOffHeapMb = 9;
     // 3. OS (add as much as possible for OS block cache)

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -18,15 +18,75 @@ option java_outer_classname = "CassandraFrameworkProtos";
 message CassandraFrameworkConfiguration {
     optional string frameworkId = 1;
     optional string frameworkName = 2;
-    optional string cassandraVersion = 3;
-    optional int32 numberOfNodes = 4;
-    optional double cpuCores = 5;
-    optional int64 memMb = 6;
-    optional int64 diskMb = 7;
     optional int64 healthCheckIntervalSeconds = 8;
-    optional int32 numberOfSeeds = 9;
     optional int64 bootstrapGraceTimeSeconds = 10;
     repeated PortMapping portMapping = 11;
+
+    // default configuration
+    required CassandraConfigRole defaultConfigRole = 6;
+    // additional configurations (currently unused)
+    repeated CassandraConfigRole configRoles = 7;
+}
+
+// CassandraConfigRole is currently only used once. But different nodes may require different sizings -
+// e.g. when replacing old metal with new metal. Different DCs may also have different sizings.
+// Individual nodes just reference a "config role".
+message CassandraConfigRole {
+    // arbitrary name of this configuration - usually "default" but could be something like "16core-128g-4x500gSSD"
+    optional string name = 1;
+
+    optional string cassandraVersion = 2;
+    optional int32 numberOfNodes = 3;
+    optional double cpuCores = 4;
+    optional int64 diskMb = 6;
+    optional int32 numberOfSeeds = 7;
+
+
+    // total memory required (must be greater than memJavaHeapMb + memAssumeOffHeapMb)
+    optional int64 memMb = 5;
+
+    // Cassandra memory usage can be categorized into
+    // 1. Java heap (MAX_HEAP_SIZE) - including new-gen (HEAP_NEWSIZE)
+    //    amount of Java heap in MB
+    //    (defaults to 50% of memMb, if not present)
+    optional int64 memJavaHeapMb = 8;
+    // 2. Off-Heap (roughly 50% of Java heap)
+    //    amount of Off heap in MB
+    //    (defaults to 50% of memMb, if not present)
+    optional int64 memAssumeOffHeapMb = 9;
+    // 3. OS (add as much as possible for OS block cache)
+    //    This is just the difference between memMb and memJavaHeapMb + memAssumeOffHeapMb
+
+    // Production grade memory configuration should include all three memory configuration parameters above.
+    // Do not forget to add as much memory for OS block cache as possible for improved performance.
+
+    // Off-heap structures (C* 2.1):
+    // - index-summary (default: 5% of the heap size)
+    //   configured in cassandra.yaml - see index_summary_capacity_in_mb
+    //   default to 5% of the heap size (may exceed)
+    // - key-cache (default: 5% of the heap size)
+    //   configured in cassandra.yaml - see key_cache_size_in_mb
+    //   default to 5% of the heap size
+    // - row-cache (default: off)
+    //   configured in cassandra.yaml - see row_cache_size_in_mb (must be explicitly enabled in taskEnv)
+    //   default to 0
+    // - counter-cache (default: min(2.5% of Heap (in MB), 50MB))
+    //   configured in cassandra.yaml - see counter_cache_size_in_mb
+    //   default: min(2.5% of Heap (in MB), 50MB) ; 0 means no cache
+    // - memtables (default on-heap)
+    //   configured in cassandra.yaml - see file_cache_size_in_mb
+    //   default to the smaller of 1/4 of heap or 512MB
+    // - file-cache (default: min(25% of Heap (in MB), 512MB))
+    //   configured in cassandra.yaml - see file_cache_size_in_mb
+    //   default to the smaller of 1/4 of heap or 512MB
+    // - overhead during flushes/compactions/cleanup
+    //   implicitly defined by workload
+
+    // additional configuration
+    // process environment
+    optional TaskEnv taskEnv = 10;
+    // cassandra.yaml configuration
+    optional TaskConfig cassandraYamlConfig = 11;
 }
 
 message PortMapping {

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -830,27 +830,4 @@ public final class CassandraCluster {
         return null;
     }
 
-    public static void fillConfigRoleGaps(CassandraConfigRole.Builder configRole) {
-        if (configRole.hasMemMb()) {
-            if (!configRole.hasMemAssumeOffHeapMb()) {
-                configRole.setMemAssumeOffHeapMb(configRole.getMemMb() / 2);
-            }
-            if (!configRole.hasMemJavaHeapMb()) {
-                configRole.setMemJavaHeapMb(configRole.getMemMb() / 2);
-            }
-        } else  {
-            if (configRole.hasMemJavaHeapMb()) {
-                if (!configRole.hasMemAssumeOffHeapMb()) {
-                    configRole.setMemAssumeOffHeapMb(configRole.getMemJavaHeapMb());
-                }
-            } else {
-                if (configRole.hasMemAssumeOffHeapMb()) {
-                    configRole.setMemJavaHeapMb(configRole.getMemAssumeOffHeapMb());
-                } else {
-                    throw new IllegalArgumentException("Config role is missing memory configuration");
-                }
-            }
-            configRole.setMemMb(configRole.getMemJavaHeapMb() + configRole.getMemAssumeOffHeapMb());
-        }
-    }
 }

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraFrameworkConfiguration.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraFrameworkConfiguration.java
@@ -28,12 +28,7 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
     public PersistedCassandraFrameworkConfiguration(
         @NotNull final State state,
         @NotNull final String frameworkName,
-        @NotNull final String cassandraVersion,
-        final int numberOfNodes,
-        final int numberOfSeeds,
-        final double cpuCores,
-        final long memMb,
-        final long diskMb,
+        @NotNull final CassandraFrameworkProtos.CassandraConfigRole defaultConfigRole,
         final long healthCheckIntervalSeconds,
         final long bootstrapGraceTimeSec
     ) {
@@ -45,12 +40,7 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
                 public CassandraFrameworkConfiguration get() {
                     return CassandraFrameworkConfiguration.newBuilder()
                         .setFrameworkName(frameworkName)
-                        .setCassandraVersion(cassandraVersion)
-                        .setNumberOfNodes(numberOfNodes)
-                        .setNumberOfSeeds(numberOfSeeds)
-                        .setCpuCores(cpuCores)
-                        .setMemMb(memMb)
-                        .setDiskMb(diskMb)
+                        .setDefaultConfigRole(defaultConfigRole)
                         .setHealthCheckIntervalSeconds(healthCheckIntervalSeconds)
                         .setBootstrapGraceTimeSeconds(bootstrapGraceTimeSec)
                         .build();
@@ -88,16 +78,8 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
         );
     }
 
-    public double cpuCores() {
-        return get().getCpuCores();
-    }
-
-    public long memMb() {
-        return get().getMemMb();
-    }
-
-    public long diskMb() {
-        return get().getDiskMb();
+    public CassandraFrameworkProtos.CassandraConfigRole getDefaultConfigRole() {
+        return get().getDefaultConfigRole();
     }
 
     @NotNull
@@ -131,42 +113,21 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
         return get().getFrameworkName();
     }
 
-    public int numberOfNodes() {
-        return get().getNumberOfNodes();
-    }
-
     public void numberOfNodes(int numberOfNodes) {
-        CassandraFrameworkConfiguration config = get();
-        if (numberOfNodes <= 0 || config.getNumberOfSeeds() > numberOfNodes || numberOfNodes < config.getNumberOfNodes())
-            throw new IllegalArgumentException("Cannot set number of nodes to " + numberOfNodes + ", current #nodes=" + config.getNumberOfNodes() + " #seeds=" + config.getNumberOfSeeds());
+        CassandraFrameworkProtos.CassandraConfigRole configRole = getDefaultConfigRole();
+        if (numberOfNodes <= 0 || configRole.getNumberOfSeeds() > numberOfNodes || numberOfNodes < configRole.getNumberOfNodes())
+            throw new IllegalArgumentException("Cannot set number of nodes to " + numberOfNodes + ", current #nodes=" + configRole.getNumberOfNodes() + " #seeds=" + configRole.getNumberOfSeeds());
 
+        setDefaultConfigRole(CassandraFrameworkProtos.CassandraConfigRole.newBuilder(configRole)
+            .setNumberOfNodes(numberOfNodes)
+            .build());
+    }
+
+    private void setDefaultConfigRole(CassandraFrameworkProtos.CassandraConfigRole configRole) {
         setValue(
-                CassandraFrameworkConfiguration.newBuilder(config)
-                        .setNumberOfNodes(numberOfNodes)
-                        .build()
+            CassandraFrameworkConfiguration.newBuilder(get())
+                .setDefaultConfigRole(configRole)
+                .build()
         );
-    }
-
-    public int numberOfSeeds() {
-        return get().getNumberOfSeeds();
-    }
-
-    public void numberOfSeeds(int seedCount) {
-        CassandraFrameworkConfiguration config = get();
-        if (seedCount <= 0 || seedCount > config.getNumberOfNodes())
-            throw new IllegalArgumentException("Cannot set number of seeds to " + seedCount + ", current #nodes=" + config.getNumberOfNodes() + " #seeds=" + config.getNumberOfSeeds());
-
-        // TODO changing the number of seeds requires rewriting cassandra.yaml (without restart)
-
-        setValue(
-                CassandraFrameworkConfiguration.newBuilder(config)
-                        .setNumberOfSeeds(seedCount)
-                        .build()
-        );
-    }
-
-    @NotNull
-    public String cassandraVersion() {
-        return get().getCassandraVersion();
     }
 }

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractSchedulerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractSchedulerTest.java
@@ -43,15 +43,19 @@ public abstract class AbstractSchedulerTest {
         // start with clean state
         state = new InMemoryState();
 
+        CassandraFrameworkProtos.CassandraConfigRole defaultConfigRole = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+            .setCassandraVersion("2.1.2")
+            .setCpuCores(2)
+            .setDiskMb(4096)
+            .setNumberOfNodes(3)
+            .setNumberOfSeeds(2)
+            .setName("default")
+            .setMemMb(4096)
+            .build();
         configuration = new PersistedCassandraFrameworkConfiguration(
                 state,
                 "test-cluster",
-                "2.1.2",
-                3, // node count
-                2, // seed count
-                2, // CPUs
-                4096, // memMb
-                4096, // diskMb
+                defaultConfigRole,
                 0, // health-check
                 0 // bootstrap-grace-time
         );

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraConfigRoleTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraConfigRoleTest.java
@@ -21,49 +21,50 @@ public class CassandraConfigRoleTest {
     @Test(expected = IllegalArgumentException.class)
     public void testMemoryParametersNone() {
         CassandraFrameworkProtos.CassandraConfigRole.Builder builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder();
-        CassandraCluster.fillConfigRoleGaps(builder);
+        PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
     }
 
     @Test()
     public void testMemoryParameters() {
         CassandraFrameworkProtos.CassandraConfigRole.Builder builder;
+        CassandraFrameworkProtos.CassandraConfigRole configRole;
 
         builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
             .setMemMb(8192);
-        CassandraCluster.fillConfigRoleGaps(builder);
-        assertThat(builder.getMemMb()).isEqualTo(8192);
-        assertThat(builder.getMemAssumeOffHeapMb()).isEqualTo(4096);
-        assertThat(builder.getMemJavaHeapMb()).isEqualTo(4096);
+        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
+        assertThat(configRole.getMemMb()).isEqualTo(8192);
+        assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
+        assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
 
         builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
             .setMemJavaHeapMb(4096);
-        CassandraCluster.fillConfigRoleGaps(builder);
-        assertThat(builder.getMemMb()).isEqualTo(8192);
-        assertThat(builder.getMemAssumeOffHeapMb()).isEqualTo(4096);
-        assertThat(builder.getMemJavaHeapMb()).isEqualTo(4096);
+        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
+        assertThat(configRole.getMemMb()).isEqualTo(8192);
+        assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
+        assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
 
         builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
             .setMemAssumeOffHeapMb(4096);
-        CassandraCluster.fillConfigRoleGaps(builder);
-        assertThat(builder.getMemMb()).isEqualTo(8192);
-        assertThat(builder.getMemAssumeOffHeapMb()).isEqualTo(4096);
-        assertThat(builder.getMemJavaHeapMb()).isEqualTo(4096);
+        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
+        assertThat(configRole.getMemMb()).isEqualTo(8192);
+        assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
+        assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
 
         builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
             .setMemJavaHeapMb(4096)
             .setMemAssumeOffHeapMb(4096);
-        CassandraCluster.fillConfigRoleGaps(builder);
-        assertThat(builder.getMemMb()).isEqualTo(8192);
-        assertThat(builder.getMemAssumeOffHeapMb()).isEqualTo(4096);
-        assertThat(builder.getMemJavaHeapMb()).isEqualTo(4096);
+        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
+        assertThat(configRole.getMemMb()).isEqualTo(8192);
+        assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
+        assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
 
         builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
             .setMemMb(10000)
             .setMemJavaHeapMb(4096)
             .setMemAssumeOffHeapMb(4096);
-        CassandraCluster.fillConfigRoleGaps(builder);
-        assertThat(builder.getMemMb()).isEqualTo(10000);
-        assertThat(builder.getMemAssumeOffHeapMb()).isEqualTo(4096);
-        assertThat(builder.getMemJavaHeapMb()).isEqualTo(4096);
+        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
+        assertThat(configRole.getMemMb()).isEqualTo(10000);
+        assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
+        assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
     }
 }

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraConfigRoleTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraConfigRoleTest.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class CassandraConfigRoleTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void testMemoryParametersNone() {
+        CassandraFrameworkProtos.CassandraConfigRole.Builder builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder();
+        CassandraCluster.fillConfigRoleGaps(builder);
+    }
+
+    @Test()
+    public void testMemoryParameters() {
+        CassandraFrameworkProtos.CassandraConfigRole.Builder builder;
+
+        builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+            .setMemMb(8192);
+        CassandraCluster.fillConfigRoleGaps(builder);
+        assertThat(builder.getMemMb()).isEqualTo(8192);
+        assertThat(builder.getMemAssumeOffHeapMb()).isEqualTo(4096);
+        assertThat(builder.getMemJavaHeapMb()).isEqualTo(4096);
+
+        builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+            .setMemJavaHeapMb(4096);
+        CassandraCluster.fillConfigRoleGaps(builder);
+        assertThat(builder.getMemMb()).isEqualTo(8192);
+        assertThat(builder.getMemAssumeOffHeapMb()).isEqualTo(4096);
+        assertThat(builder.getMemJavaHeapMb()).isEqualTo(4096);
+
+        builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+            .setMemAssumeOffHeapMb(4096);
+        CassandraCluster.fillConfigRoleGaps(builder);
+        assertThat(builder.getMemMb()).isEqualTo(8192);
+        assertThat(builder.getMemAssumeOffHeapMb()).isEqualTo(4096);
+        assertThat(builder.getMemJavaHeapMb()).isEqualTo(4096);
+
+        builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+            .setMemJavaHeapMb(4096)
+            .setMemAssumeOffHeapMb(4096);
+        CassandraCluster.fillConfigRoleGaps(builder);
+        assertThat(builder.getMemMb()).isEqualTo(8192);
+        assertThat(builder.getMemAssumeOffHeapMb()).isEqualTo(4096);
+        assertThat(builder.getMemJavaHeapMb()).isEqualTo(4096);
+
+        builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+            .setMemMb(10000)
+            .setMemJavaHeapMb(4096)
+            .setMemAssumeOffHeapMb(4096);
+        CassandraCluster.fillConfigRoleGaps(builder);
+        assertThat(builder.getMemMb()).isEqualTo(10000);
+        assertThat(builder.getMemAssumeOffHeapMb()).isEqualTo(4096);
+        assertThat(builder.getMemJavaHeapMb()).isEqualTo(4096);
+    }
+}


### PR DESCRIPTION
Memory used by C* is can be roughly categorizes into:
* Java heap
* Off heap (more detailed in readme)
* OS block cache

In the simplest mode (just providing `memMb`), i.e. `javaHeap = offHeap = memMb / 2`. Memory sizing will always work if at least one of `memMb`, `memJavaHeapMb` or `memAssumeOffHeapMb` is provided.
A real production deployment however should include at least `memMb` and `memJavaHeapMb` according to the real workload. Even better: provide descent values for all (required) configuration options (environment + `cassandra.yaml`) and memory sizing.

Factored out per-DC / per-node specific configuration to `CassandraConfigRole`. At the moment it does not have any useful meaning (except moving config to a specialized structure). But we can use it in the future to scale-up nodes (e.g. double cores, double ram) one-after-another or to define different settings by DC. In the future it should would by assigning a "config-role-name" to a DC or node and lookup the config-role in `CassandraFrameworkConfiguration.configRoles`.