### PR TITLE
C node restart

### DIFF
--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutor.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutor.java
@@ -441,6 +441,9 @@ public final class CassandraExecutor implements Executor {
 
             forceCurrentJobAbort();
 
+            // send health check that process is no longer alive
+            healthCheck(driver);
+
         } catch (IllegalThreadStateException e) {
             // ignore
         }

--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ProdObjectFactory.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ProdObjectFactory.java
@@ -30,7 +30,7 @@ import java.util.Map;
 
 // production object factory - there's another implementation, that's used for mocked unit tests
 final class ProdObjectFactory implements ObjectFactory {
-    private static final Logger LOGGER = LoggerFactory.getLogger(CassandraExecutor.class);
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProdObjectFactory.class);
 
     @Override
     public JmxConnect newJmxConnect(CassandraFrameworkProtos.JmxConnect jmx) {
@@ -64,23 +64,11 @@ final class ProdObjectFactory implements ObjectFactory {
         processBuilder.environment().put("JAVA_HOME", System.getProperty("java.home"));
         if (LOGGER.isDebugEnabled())
             LOGGER.debug("Starting Process: {}", processBuilderToString(processBuilder));
-        final Process p;
         try {
-            p = processBuilder.start();
+            return new ProdWrappedProcess(processBuilder.start());
         } catch (IOException e) {
             throw new LaunchNodeException("Failed to start process", e);
         }
-        return new WrappedProcess() {
-            @Override
-            public void destroy() {
-                p.destroy();
-            }
-
-            @Override
-            public int exitValue() {
-                return p.exitValue();
-            }
-        };
     }
 
     @NotNull

--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ProdWrappedProcess.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ProdWrappedProcess.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Field;
+
+class ProdWrappedProcess implements WrappedProcess {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProdWrappedProcess.class);
+
+    private final Process p;
+    private final int pid;
+
+    private static final Field pidField;
+
+    static {
+        try {
+            Class cls = Class.forName("java.lang.UNIXProcess");
+            pidField = cls.getDeclaredField("pid");
+            pidField.setAccessible(true);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    ProdWrappedProcess(Process p) {
+        this.p = p;
+
+        try {
+            pid = pidField.getInt(p);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException("not on Unix??", e);
+        }
+    }
+
+    @Override
+    public int getPid() {
+        return pid;
+    }
+
+    @Override
+    public void destroy() {
+        LOGGER.info("Terminating process with PID {}", pid);
+        p.destroy();
+    }
+
+    @Override
+    public void destroyForcibly() {
+        // note: with Java8 this can be a call to Process.destroyForcibly()
+
+        LOGGER.info("Killing process with PID {}", pid);
+        try {
+            Process killProc = new ProcessBuilder("kill", "-9", Integer.toString(pid)).start();
+            killProc.waitFor();
+        } catch (Exception e) {
+            LOGGER.error("Failed to forcibly terminate process with PID " + pid, e);
+        }
+    }
+
+    @Override
+    public int exitValue() {
+        int exitCode = p.exitValue();
+        return exitCode;
+    }
+}

--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/WrappedProcess.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/WrappedProcess.java
@@ -16,5 +16,9 @@ package io.mesosphere.mesos.frameworks.cassandra;
 public interface WrappedProcess {
     void destroy();
 
-    int exitValue();
+    void destroyForcibly();
+
+    int exitValue() throws IllegalThreadStateException;
+
+    int getPid();
 }

--- a/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/MockExecutorDriver.java
+++ b/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/MockExecutorDriver.java
@@ -120,17 +120,21 @@ public class MockExecutorDriver implements ExecutorDriver {
     public void launchTask(Protos.TaskID taskId, Protos.CommandInfo commandInfo, CassandraFrameworkProtos.TaskDetails taskDetails,
                            String name, Iterable<? extends Protos.Resource> resources) {
         executor.launchTask(this, Protos.TaskInfo.newBuilder()
-                .setTaskId(taskId)
-                .setCommand(commandInfo)
-                .setData(taskDetails.toByteString())
-                .setExecutor(executorInfo)
-                .setName(name)
-                .addAllResources(resources)
-                .setSlaveId(slaveInfo.getId())
-                .build());
+            .setTaskId(taskId)
+            .setCommand(commandInfo)
+            .setData(taskDetails.toByteString())
+            .setExecutor(executorInfo)
+            .setName(name)
+            .addAllResources(resources)
+            .setSlaveId(slaveInfo.getId())
+            .build());
     }
 
     public void frameworkMessage(CassandraFrameworkProtos.TaskDetails taskDetails) {
         executor.frameworkMessage(this, taskDetails.toByteArray());
+    }
+
+    public void killTask(Protos.TaskID taskId) {
+        executor.killTask(this, taskId);
     }
 }

--- a/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/TestObjectFactory.java
+++ b/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/TestObjectFactory.java
@@ -45,6 +45,7 @@ class TestObjectFactory implements ObjectFactory {
     final String hostId = UUID.randomUUID().toString();
     final MockStorageService storageServiceProxy = new MockStorageService();
     final MockEndpointSnitchInfo endpointSnitchInfo = new MockEndpointSnitchInfo();
+    TestWrappedProcess process;
 
     @Override
     public JmxConnect newJmxConnect(CassandraFrameworkProtos.JmxConnect jmx) {
@@ -53,18 +54,28 @@ class TestObjectFactory implements ObjectFactory {
 
     @Override
     public WrappedProcess launchCassandraNodeTask(Marker taskIdMarker, CassandraFrameworkProtos.CassandraServerRunTask cassandraServerRunTask) throws LaunchNodeException {
-        return new WrappedProcess() {
+        return process = new TestWrappedProcess();
+    }
 
-            @Override
-            public void destroy() {
-                throw new UnsupportedOperationException();
-            }
+    private static class TestWrappedProcess implements WrappedProcess {
 
-            @Override
-            public int exitValue() {
+        int exitCode = -1;
+
+        @Override
+        public void destroy() {
+            // nop
+        }
+
+        @Override
+        public int exitValue() {
+            if (exitCode == -1)
                 throw new IllegalThreadStateException();
-            }
-        };
+            return exitCode;
+        }
+
+        public void daemonStopped() {
+            exitCode = 0;
+        }
     }
 
     final class TestJmxConnect implements JmxConnect {
@@ -253,6 +264,11 @@ class TestObjectFactory implements ObjectFactory {
             for (NotificationListener listener : new ArrayList<>(listeners)) {
                 listener.handleNotification(notification, null);
             }
+        }
+
+        @Override
+        public void stopDaemon() {
+            process.daemonStopped();
         }
 
         //
@@ -501,11 +517,6 @@ class TestObjectFactory implements ObjectFactory {
 
         @Override
         public void startGossiping() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void stopDaemon() {
             throw new UnsupportedOperationException();
         }
 

--- a/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/TestObjectFactory.java
+++ b/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/TestObjectFactory.java
@@ -62,7 +62,17 @@ class TestObjectFactory implements ObjectFactory {
         int exitCode = -1;
 
         @Override
+        public int getPid() {
+            return 42;
+        }
+
+        @Override
         public void destroy() {
+            daemonStopped();
+        }
+
+        @Override
+        public void destroyForcibly() {
             // nop
         }
 

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -166,12 +166,26 @@ message CassandraNode {
     repeated DataVolume dataVolumes = 4;
     optional CassandraNodeExecutor cassandraNodeExecutor = 5;
 
-    optional CassandraNodeTask metadataTask = 6;
-    optional CassandraNodeTask serverTask = 7;
+    repeated CassandraNodeTask tasks = 6;
 
     required bool seed = 8;
     optional int64 lastRepairTimestamp = 9;
     optional int64 lastCleanupTimestamp = 10;
+
+    // Indicates whether a node should run or not.
+    required TargetRunState targetRunState = 11;
+
+    enum TargetRunState {
+        // If the server task is not active, it is started.
+        // Note that general bootstrap-grace-time settings and other checks (e.g. currently other nodes joining) apply.
+        RUN = 0;
+        // If the server-task is active, a server-task shutdown is initiated.
+        STOP = 1;
+        // If the server task is not active, the state is immediately set to RUN.
+        // If the server-task is active, a server-task shutdown is initiated.
+        // Note that general bootstrap-grace-time settings and other checks (e.g. currently other nodes joining) apply.
+        RESTART = 2;
+    }
 }
 message DataVolume {
     required string path = 1;
@@ -199,14 +213,22 @@ message URI {
 }
 
 message CassandraNodeTask {
-    required string taskId = 1;
-    required string executorId = 2;
-    required double cpuCores = 3;
-    required int64 memMb = 4;
-    required int64 diskMb = 5;
-    repeated int64 ports = 6;
+    required TaskType taskType = 1;
+    required string taskId = 2;
+    required string executorId = 3;
+    required double cpuCores = 4;
+    required int64 memMb = 5;
+    required int64 diskMb = 6;
+    repeated int64 ports = 7;
 
-    optional TaskDetails taskDetails = 7;
+    optional TaskDetails taskDetails = 8;
+
+    enum TaskType {
+        METADATA = 1;
+        SERVER = 2;
+        SERVER_SHUTDOWN = 3;
+        CLUSTER_JOB = 4;
+    }
 }
 
 message TaskDetails {

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -175,6 +175,8 @@ message CassandraNode {
     // Indicates whether a node should run or not.
     required TargetRunState targetRunState = 11;
 
+    optional int32 cassandraDaemonPid = 12;
+
     enum TargetRunState {
         // If the server task is not active, it is started.
         // Note that general bootstrap-grace-time settings and other checks (e.g. currently other nodes joining) apply.
@@ -226,8 +228,7 @@ message CassandraNodeTask {
     enum TaskType {
         METADATA = 1;
         SERVER = 2;
-        SERVER_SHUTDOWN = 3;
-        CLUSTER_JOB = 4;
+        CLUSTER_JOB = 3;
     }
 }
 
@@ -235,17 +236,14 @@ message TaskDetails {
     required TaskType taskType = 1;
     optional ExecutorMetadataTask executorMetadataTask = 2;
     optional CassandraServerRunTask cassandraServerRunTask = 3;
-    optional CassandraServerShutdownTask cassandraServerShutdownTask = 4;
-    optional HealthCheckTask healthCheckTask = 5;
-    optional NodeJobTask nodeJobTask = 6;
+    optional NodeJobTask nodeJobTask = 4;
 
     enum TaskType {
         EXECUTOR_METADATA = 1;
         CASSANDRA_SERVER_RUN = 2;
-        CASSANDRA_SERVER_SHUTDOWN = 3;
-        HEALTH_CHECK = 4;
-        NODE_JOB = 5;
-        NODE_JOB_STATUS = 6;
+        HEALTH_CHECK = 3;
+        NODE_JOB = 4;
+        NODE_JOB_STATUS = 5;
     }
 }
 
@@ -261,12 +259,6 @@ message CassandraServerRunTask {
     repeated TaskFile taskFiles = 4;
     required TaskConfig taskConfig = 5;
     required JmxConnect jmx = 6;
-}
-
-message CassandraServerShutdownTask {
-}
-
-message HealthCheckTask {
 }
 
 message NodeJobTask {
@@ -313,22 +305,28 @@ message TaskEnv {
 message SlaveStatusDetails {
     required StatusDetailsType statusDetailsType = 1;
     optional ExecutorMetadata executorMetadata = 2;
-    optional SlaveErrorDetails slaveErrorDetails = 3;
-    optional HealthCheckDetails healthCheckDetails = 4;
-    optional NodeJobStatus nodeJobStatus = 5;
+    optional CassandraServerRunMetadata cassandraServerRunMetadata = 3;
+    optional SlaveErrorDetails slaveErrorDetails = 4;
+    optional HealthCheckDetails healthCheckDetails = 5;
+    optional NodeJobStatus nodeJobStatus = 6;
 
     enum StatusDetailsType {
         NULL_DETAILS = 1;
         EXECUTOR_METADATA = 2;
-        ERROR_DETAILS = 3;
-        HEALTH_CHECK_DETAILS = 4;
-        NODE_JOB_STATUS = 5;
+        CASSANDRA_SERVER_RUN = 3;
+        ERROR_DETAILS = 4;
+        HEALTH_CHECK_DETAILS = 5;
+        NODE_JOB_STATUS = 6;
     }
 }
 
 message ExecutorMetadata {
     required string executorId = 1;
     optional string ip = 2;
+}
+
+message CassandraServerRunMetadata {
+    required int32 pid = 1;
 }
 
 message SlaveErrorDetails {

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -21,10 +21,7 @@ import io.mesosphere.mesos.util.CassandraFrameworkProtosUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
@@ -308,7 +305,7 @@ public final class ApiController {
 
     // cluster scaling
 
-    @GET
+    @POST
     @Path("/scale/nodes")
     public Response updateNodeCount(@QueryParam("nodes") int nodeCount) {
         StringWriter sw = new StringWriter();
@@ -545,7 +542,7 @@ public final class ApiController {
 
     // node run / stop / restart
 
-    @GET
+    @POST
     @Path("/node/stop/{node}")
     public Response nodeStop(@PathParam("node") String node) {
         CassandraFrameworkProtos.CassandraNode cassandraNode = cluster.nodeStop(node);
@@ -553,7 +550,7 @@ public final class ApiController {
         return nodeStatusUpdate(cassandraNode);
     }
 
-    @GET
+    @POST
     @Path("/node/run/{node}")
     public Response nodeStart(@PathParam("node") String node) {
         CassandraFrameworkProtos.CassandraNode cassandraNode = cluster.nodeRun(node);
@@ -561,7 +558,7 @@ public final class ApiController {
         return nodeStatusUpdate(cassandraNode);
     }
 
-    @GET
+    @POST
     @Path("/node/restart/{node}")
     public Response nodeRestart(@PathParam("node") String node) {
         CassandraFrameworkProtos.CassandraNode cassandraNode = cluster.nodeRestart(node);

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -189,13 +189,18 @@ public final class ApiController {
                 writeTask(json, "metadataTask", CassandraFrameworkProtosUtils.getTaskForNode(cassandraNode, CassandraFrameworkProtos.CassandraNodeTask.TaskType.METADATA));
 // TODO                cassandraNode.getDataVolumesList();
 
-                json.writeStringField("executorId", cassandraNode.getCassandraNodeExecutor().getExecutorId());
+                if (!cassandraNode.hasCassandraNodeExecutor()) {
+                    json.writeNullField("executorId");
+                } else {
+                    json.writeStringField("executorId", cassandraNode.getCassandraNodeExecutor().getExecutorId());
+                }
                 json.writeStringField("ip", cassandraNode.getIp());
                 json.writeStringField("hostname", cassandraNode.getHostname());
                 json.writeStringField("targetRunState", cassandraNode.getTargetRunState().name());
                 json.writeNumberField("jmxPort", cassandraNode.getJmxConnect().getJmxPort());
 
-                CassandraFrameworkProtos.HealthCheckHistoryEntry lastHealthCheck = cluster.lastHealthCheck(cassandraNode.getCassandraNodeExecutor().getExecutorId());
+                CassandraFrameworkProtos.HealthCheckHistoryEntry lastHealthCheck =
+                    cassandraNode.hasCassandraNodeExecutor() ? cluster.lastHealthCheck(cassandraNode.getCassandraNodeExecutor().getExecutorId()) : null;
 
                 if (lastHealthCheck != null)
                     json.writeNumberField("lastHealthCheck", lastHealthCheck.getTimestampEnd());
@@ -573,7 +578,9 @@ public final class ApiController {
             } else {
                 json.writeStringField("ip", cassandraNode.getIp());
                 json.writeStringField("hostname", cassandraNode.getHostname());
-                if (cassandraNode.hasCassandraNodeExecutor()) {
+                if (!cassandraNode.hasCassandraNodeExecutor()) {
+                    json.writeNullField("executorId");
+                } else {
                     json.writeStringField("executorId", cassandraNode.getCassandraNodeExecutor().getExecutorId());
                 }
                 json.writeStringField("targetRunState", cassandraNode.getTargetRunState().name());

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -198,6 +198,12 @@ public final class ApiController {
                 json.writeStringField("hostname", cassandraNode.getHostname());
                 json.writeStringField("targetRunState", cassandraNode.getTargetRunState().name());
                 json.writeNumberField("jmxPort", cassandraNode.getJmxConnect().getJmxPort());
+                json.writeBooleanField("seedNode", cassandraNode.getSeed());
+                if (!cassandraNode.hasCassandraDaemonPid()) {
+                    json.writeNullField("cassandraDaemonPid");
+                } else {
+                    json.writeNumberField("cassandraDaemonPid", cassandraNode.getCassandraDaemonPid());
+                }
 
                 CassandraFrameworkProtos.HealthCheckHistoryEntry lastHealthCheck =
                     cassandraNode.hasCassandraNodeExecutor() ? cluster.lastHealthCheck(cassandraNode.getCassandraNodeExecutor().getExecutorId()) : null;

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -272,7 +272,7 @@ public final class CassandraCluster {
             if (nodeOpt.isPresent()) {
                 LOGGER.info(
                     "health check result unhealthy for node: {}. Message: '{}'",
-                    nodeOpt.get().getCassandraNodeExecutor().getExecutorId(),
+                    nodeOpt.get().hasCassandraNodeExecutor() ? nodeOpt.get().getCassandraNodeExecutor().getExecutorId() : "??",
                     details.getMsg()
                     );
                 // TODO: This needs to be smarter, right not it assumes that as soon as it's unhealth it's dead
@@ -842,7 +842,9 @@ public final class CassandraCluster {
                 .setStartedTimestamp(clock.now().getMillis());
 
         for (CassandraNode cassandraNode : clusterState.nodes()) {
-            builder.addRemainingNodes(cassandraNode.getCassandraNodeExecutor().getExecutorId());
+            if (cassandraNode.hasCassandraNodeExecutor()) {
+                builder.addRemainingNodes(cassandraNode.getCassandraNodeExecutor().getExecutorId());
+            }
         }
 
         jobsState.currentJob(builder.build());

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/TasksForOffer.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/TasksForOffer.java
@@ -22,11 +22,13 @@ public class TasksForOffer {
     private final CassandraFrameworkProtos.CassandraNodeExecutor executor;
     private final List<CassandraFrameworkProtos.CassandraNodeTask> launchTasks;
     private final List<CassandraFrameworkProtos.TaskDetails> submitTasks;
+    private final List<Protos.TaskID> killTasks;
 
     public TasksForOffer(CassandraFrameworkProtos.CassandraNodeExecutor executor) {
         this.executor = executor;
         this.launchTasks = new ArrayList<>();
         this.submitTasks = new ArrayList<>();
+        this.killTasks = new ArrayList<>();
     }
 
     public CassandraFrameworkProtos.CassandraNodeExecutor getExecutor() {
@@ -41,8 +43,12 @@ public class TasksForOffer {
         return submitTasks;
     }
 
+    public List<Protos.TaskID> getKillTasks() {
+        return killTasks;
+    }
+
     public boolean hasAnyTask() {
-        return !submitTasks.isEmpty() || !launchTasks.isEmpty();
+        return !submitTasks.isEmpty() || !launchTasks.isEmpty() || !killTasks.isEmpty();
     }
 
     public boolean hasExecutor() {

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraClusterStateTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraClusterStateTest.java
@@ -13,6 +13,7 @@
  */
 package io.mesosphere.mesos.frameworks.cassandra;
 
+import io.mesosphere.mesos.util.CassandraFrameworkProtosUtils;
 import io.mesosphere.mesos.util.Tuple2;
 import org.apache.mesos.Protos;
 import org.junit.Test;
@@ -162,7 +163,9 @@ public class CassandraClusterStateTest extends AbstractSchedulerTest {
         // cluster now up with 3 running nodes
 
         // server-task no longer running
-        cluster.removeTask(cluster.cassandraNodeForHostname(slaves[0]._2).get().getServerTask().getTaskId(), null);
+        CassandraFrameworkProtos.CassandraNodeTask serverTask = CassandraFrameworkProtosUtils.getTaskForNode(cluster.cassandraNodeForHostname(slaves[0]._2).get(), CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER);
+        assertNotNull(serverTask);
+        cluster.removeTask(serverTask.getTaskId(), null);
 
         // server-task cannot start again
         launchServer(cluster, slaves[0]);

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraSchedulerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraSchedulerTest.java
@@ -51,15 +51,17 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.STOP, node1.getTargetRunState());
 
-        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+        CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER);
+        assertNotNull(taskForNode);
 
-        // verify that CASSANDRA_SERVER_SHUTDOWN task is launched
-        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_SHUTDOWN);
+        // verify that kill-task is launched
+        killTask(slaves[0], taskForNode.getTaskId());
         // must not repeat CASSANDRA_SERVER_SHUTDOWN since it's already launched
-        noopOnOffer(slaves[0], 3);
+        noopOnOffer(slaves[0], 3, true);
 
         // re-check that server-task is still present
         node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
         assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
 
         // simulate server-task has finished
@@ -69,6 +71,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // check that server-task is no longer present
         node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
         assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
 
 
@@ -85,6 +88,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // check that server-task is present
         node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RUN, node1.getTargetRunState());
         assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
 
@@ -108,15 +112,17 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node1.getTargetRunState());
 
-        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+        CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER);
+        assertNotNull(taskForNode);
 
-        // verify that CASSANDRA_SERVER_SHUTDOWN task is launched
-        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_SHUTDOWN);
+        // verify that kill-task is launched
+        killTask(slaves[0], taskForNode.getTaskId());
         // must not repeat CASSANDRA_SERVER_SHUTDOWN since it's already launched
-        noopOnOffer(slaves[0], 3);
+        noopOnOffer(slaves[0], 3, true);
 
         // re-check that server-task is still present
         node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node1.getTargetRunState());
         assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
 
@@ -127,6 +133,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // check that server-task is no longer present
         node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node1.getTargetRunState());
         assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
 
@@ -139,6 +146,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // check that server-task is present
         node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RUN, node1.getTargetRunState());
         assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
 
@@ -426,6 +434,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         // 2nd node
 
         taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB);
+        assertNotNull(taskInfo);
         Protos.TaskInfo taskInfo2 = taskInfo;
         Assert.assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
         Assert.assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
@@ -461,6 +470,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         // 3rd node
 
         taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB);
+        assertNotNull(taskInfo);
         Assert.assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
         Assert.assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
         Assert.assertNotEquals(executorId(taskInfo), executorId(taskInfo2));
@@ -613,6 +623,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         // 2nd node
 
         taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB);
+        assertNotNull(taskInfo);
         Protos.TaskInfo taskInfo2 = taskInfo;
         Assert.assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
         Assert.assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
@@ -642,6 +653,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         // 3rd node
 
         taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB);
+        assertNotNull(taskInfo);
         Assert.assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
         Assert.assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
         Assert.assertNotEquals(executorId(taskInfo), executorId(taskInfo2));
@@ -833,6 +845,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         Tuple2<Collection<Protos.OfferID>, Collection<Protos.TaskInfo>> launchTasks = driver.launchTasks();
         assertTrue(driver.declinedOffers().isEmpty());
         assertTrue(driver.submitTasks().isEmpty());
+        assertTrue(driver.killTasks().isEmpty());
 
         assertEquals(nodeCount, cluster.getClusterState().get().getNodesCount());
         assertEquals(1, launchTasks._2.size());
@@ -856,6 +869,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
             assertEquals(1, launchTasks._2.size());
             assertTrue(driver.submitTasks().isEmpty());
+            assertTrue(driver.killTasks().isEmpty());
 
             Protos.TaskInfo taskInfo = launchTasks._2.iterator().next();
 
@@ -875,12 +889,27 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         Tuple2<Collection<Protos.OfferID>, Collection<Protos.TaskInfo>> launchTasks = driver.launchTasks();
         assertTrue(launchTasks._2.isEmpty());
         Collection<Tuple2<Protos.ExecutorID, CassandraFrameworkProtos.TaskDetails>> submitTasks = driver.submitTasks();
+        assertTrue(driver.killTasks().isEmpty());
 
         assertEquals(1, submitTasks.size());
 
         CassandraFrameworkProtos.TaskDetails taskDetails = submitTasks.iterator().next()._2;
         assertEquals(taskType, taskDetails.getTaskType());
         return taskDetails;
+    }
+
+    private void killTask(Tuple2<Protos.SlaveID, String> slave, String taskID) {
+        Protos.Offer offer = createOffer(slave);
+
+        scheduler.resourceOffers(driver, Collections.singletonList(offer));
+
+        assertThat(driver.declinedOffers())
+            .hasSize(1);
+        assertTrue(driver.launchTasks()._2.isEmpty());
+        assertTrue(driver.submitTasks().isEmpty());
+        assertThat(driver.killTasks())
+            .hasSize(1)
+            .contains(Protos.TaskID.newBuilder().setValue(taskID).build());
     }
 
     private Tuple2<Protos.TaskInfo, CassandraFrameworkProtos.TaskDetails> launchTask(Tuple2<Protos.SlaveID, String> slave, CassandraFrameworkProtos.TaskDetails.TaskType taskType) throws InvalidProtocolBufferException {
@@ -891,6 +920,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         assertTrue(driver.declinedOffers().isEmpty());
         Tuple2<Collection<Protos.OfferID>, Collection<Protos.TaskInfo>> launchTasks = driver.launchTasks();
         assertTrue(driver.submitTasks().isEmpty());
+        assertTrue(driver.killTasks().isEmpty());
 
         assertEquals(1, launchTasks._2.size());
 
@@ -906,12 +936,20 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
     }
 
     private void noopOnOffer(Tuple2<Protos.SlaveID, String> slave, int nodeCount) {
+        noopOnOffer(slave, nodeCount, false);
+    }
+
+    private void noopOnOffer(Tuple2<Protos.SlaveID, String> slave, int nodeCount, boolean ignoreKills) {
         Protos.Offer offer = createOffer(slave);
 
         scheduler.resourceOffers(driver, Collections.singletonList(offer));
 
         Tuple2<Collection<Protos.OfferID>, Collection<Protos.TaskInfo>> launchTasks = driver.launchTasks();
         assertTrue(ProtoUtils.protoToString(driver.submitTasks()), driver.submitTasks().isEmpty());
+        boolean noKills = driver.killTasks().isEmpty();
+        if (!ignoreKills) {
+            assertTrue(noKills);
+        }
         List<Protos.OfferID> decl = driver.declinedOffers();
         assertThat(decl)
             .hasSize(1)

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/MockSchedulerDriver.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/MockSchedulerDriver.java
@@ -26,6 +26,7 @@ public class MockSchedulerDriver implements SchedulerDriver {
     private final Protos.MasterInfo masterInfo;
     private Tuple2<Collection<Protos.OfferID>, Collection<Protos.TaskInfo>> launchTasks = clearLaunchTasks();
     private Collection<Tuple2<Protos.ExecutorID, CassandraFrameworkProtos.TaskDetails>> submitTasks = clearSubmitTasks();
+    private Collection<Protos.TaskID> killTasks = clearKillTasks();
 
     private List<Protos.OfferID> declinedOffers = new ArrayList<>();
 
@@ -47,7 +48,8 @@ public class MockSchedulerDriver implements SchedulerDriver {
 
     @Override
     public Protos.Status killTask(Protos.TaskID taskId) {
-        throw new UnsupportedOperationException();
+        killTasks.add(taskId);
+        return Protos.Status.DRIVER_RUNNING;
     }
 
     @Override
@@ -155,6 +157,14 @@ public class MockSchedulerDriver implements SchedulerDriver {
         }
     }
 
+    public Collection<Protos.TaskID> killTasks() {
+        try {
+            return killTasks;
+        } finally {
+            killTasks = clearKillTasks();
+        }
+    }
+
     public Collection<Tuple2<Protos.ExecutorID, CassandraFrameworkProtos.TaskDetails>> submitTasks() {
         try {
             return submitTasks;
@@ -168,6 +178,10 @@ public class MockSchedulerDriver implements SchedulerDriver {
     }
 
     private static Collection<Tuple2<Protos.ExecutorID, CassandraFrameworkProtos.TaskDetails>> clearSubmitTasks() {
+        return new ArrayList<>();
+    }
+
+    private static Collection<Protos.TaskID> clearKillTasks() {
         return new ArrayList<>();
     }
 }


### PR DESCRIPTION
Adds:
* Cassandra server shutdown
* Cassandra server start
* Cassandra server restart

To do that, a `TargetRunState` enum is introduced. It knows three states: `RUN`=node has to run, `STOP`=node should not run, `RESTART`=stop and start node (sets state to `RUN` afterwards)

Since a new task ID (`shutdown`) is being introduced (and a follow-up PR introduces a new state `TERMINATE` along with another new task `terminate`) I've change refactored the `metadataTask` and `serverTask` fields to a general-purpose list of `CassandraNode.tasks`.