### PR TITLE
bounded health check history

### DIFF
--- a/cassandra-mesos-model/src/main/java/io/mesosphere/mesos/util/CassandraFrameworkProtosUtils.java
+++ b/cassandra-mesos-model/src/main/java/io/mesosphere/mesos/util/CassandraFrameworkProtosUtils.java
@@ -343,7 +343,7 @@ public final class CassandraFrameworkProtosUtils {
 
         @Override
         public Long apply(@NotNull final HealthCheckHistoryEntry input) {
-            return input.getTimestampLast();
+            return input.getTimestampEnd();
         }
     }
 

--- a/cassandra-mesos-model/src/main/java/io/mesosphere/mesos/util/CassandraFrameworkProtosUtils.java
+++ b/cassandra-mesos-model/src/main/java/io/mesosphere/mesos/util/CassandraFrameworkProtosUtils.java
@@ -343,7 +343,7 @@ public final class CassandraFrameworkProtosUtils {
 
         @Override
         public Long apply(@NotNull final HealthCheckHistoryEntry input) {
-            return input.getTimestamp();
+            return input.getTimestampLast();
         }
     }
 

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -47,8 +47,8 @@ message CassandraClusterHealthCheckHistory {
 
 message HealthCheckHistoryEntry {
     required string executorId = 1;
-    required int64 timestampFirst = 2;
-    required int64 timestampLast = 3;
+    required int64 timestampStart = 2;
+    required int64 timestampEnd = 3;
     required HealthCheckDetails details = 4;
 }
 

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -111,11 +111,9 @@ message CassandraNode {
     optional CassandraNodeTask metadataTask = 6;
     optional CassandraNodeTask serverTask = 7;
 
-    repeated HealthCheckDetails healthCheckHistory = 8;
-
-    required bool seed = 9;
-    optional int64 lastRepairTimestamp = 10;
-    optional int64 lastCleanupTimestamp = 11;
+    required bool seed = 8;
+    optional int64 lastRepairTimestamp = 9;
+    optional int64 lastCleanupTimestamp = 10;
 }
 message DataVolume {
     required string path = 1;

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -41,13 +41,15 @@ message CassandraClusterState {
 }
 
 message CassandraClusterHealthCheckHistory {
-    repeated HealthCheckHistoryEntry entries = 1;
+    required int32 maxEntriesPerNode = 1;
+    repeated HealthCheckHistoryEntry entries = 2;
 }
 
 message HealthCheckHistoryEntry {
     required string executorId = 1;
-    required int64 timestamp = 2;
-    required HealthCheckDetails details = 3;
+    required int64 timestampFirst = 2;
+    required int64 timestampLast = 3;
+    required HealthCheckDetails details = 4;
 }
 
 enum ClusterJobType {

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -194,7 +194,7 @@ public final class ApiController {
                 CassandraFrameworkProtos.HealthCheckHistoryEntry lastHealthCheck = cluster.lastHealthCheck(cassandraNode.getCassandraNodeExecutor().getExecutorId());
 
                 if (lastHealthCheck != null)
-                    json.writeNumberField("lastHealthCheck", lastHealthCheck.getTimestamp());
+                    json.writeNumberField("lastHealthCheck", lastHealthCheck.getTimestampLast());
                 else
                     json.writeNullField("lastHealthCheck");
 

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -194,7 +194,7 @@ public final class ApiController {
                 CassandraFrameworkProtos.HealthCheckHistoryEntry lastHealthCheck = cluster.lastHealthCheck(cassandraNode.getCassandraNodeExecutor().getExecutorId());
 
                 if (lastHealthCheck != null)
-                    json.writeNumberField("lastHealthCheck", lastHealthCheck.getTimestampLast());
+                    json.writeNumberField("lastHealthCheck", lastHealthCheck.getTimestampEnd());
                 else
                     json.writeNullField("lastHealthCheck");
 

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -277,13 +277,7 @@ public final class CassandraCluster {
                 //removeTask(nodeOpt.get().getServerTask().getTaskId());
             }
         }
-        healthCheckHistory.record(
-            HealthCheckHistoryEntry.newBuilder()
-                .setExecutorId(executorId)
-                .setTimestamp(clock.now().getMillis())
-                .setDetails(details)
-                .build()
-        );
+        healthCheckHistory.record(executorId, clock.now().getMillis(), details);
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("< recordHealthCheck(executorId : {}, details : {})", executorId, protoToString(details));
         }

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterHealthCheckHistory.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterHealthCheckHistory.java
@@ -15,14 +15,18 @@ package io.mesosphere.mesos.frameworks.cassandra;
 
 import com.google.common.base.Function;
 import com.google.common.base.Supplier;
+import com.google.protobuf.Descriptors;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.mesosphere.mesos.util.ProtoUtils;
 import org.apache.mesos.state.State;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 final class PersistedCassandraClusterHealthCheckHistory extends StatePersistedObject<CassandraFrameworkProtos.CassandraClusterHealthCheckHistory> {
+    static final int DEFAULT_MAX_ENTRIES_PER_NODE = 5;
+
     public PersistedCassandraClusterHealthCheckHistory(
         @NotNull final State state
     ) {
@@ -32,7 +36,9 @@ final class PersistedCassandraClusterHealthCheckHistory extends StatePersistedOb
             new Supplier<CassandraFrameworkProtos.CassandraClusterHealthCheckHistory>() {
                 @Override
                 public CassandraFrameworkProtos.CassandraClusterHealthCheckHistory get() {
-                    return CassandraFrameworkProtos.CassandraClusterHealthCheckHistory.newBuilder().build();
+                    return CassandraFrameworkProtos.CassandraClusterHealthCheckHistory.newBuilder()
+                        .setMaxEntriesPerNode(DEFAULT_MAX_ENTRIES_PER_NODE)
+                        .build();
                 }
             },
             new Function<byte[], CassandraFrameworkProtos.CassandraClusterHealthCheckHistory>() {
@@ -59,24 +65,108 @@ final class PersistedCassandraClusterHealthCheckHistory extends StatePersistedOb
         return get().getEntriesList();
     }
 
-    public void record(@NotNull final CassandraFrameworkProtos.HealthCheckHistoryEntry entry) {
-        //TODO(BenWhitehead): Bound this
-        setValue(
-            CassandraFrameworkProtos.CassandraClusterHealthCheckHistory.newBuilder(get())
-                .addEntries(entry)
-                .build()
-        );
+    @NotNull
+    public List<CassandraFrameworkProtos.HealthCheckHistoryEntry> entriesForExecutor(String executorId) {
+        CassandraFrameworkProtos.CassandraClusterHealthCheckHistory history = get();
+        List<CassandraFrameworkProtos.HealthCheckHistoryEntry> forNode = new ArrayList<>(history.getMaxEntriesPerNode());
+        int count = history.getEntriesCount();
+        for (int i = 0; i < count; i++) {
+            CassandraFrameworkProtos.HealthCheckHistoryEntry hc = history.getEntries(i);
+            if (executorId.equals(hc.getExecutorId()))
+                forNode.add(hc);
+        }
+        return forNode;
     }
 
     public CassandraFrameworkProtos.HealthCheckHistoryEntry last(String executorId) {
-        List<CassandraFrameworkProtos.HealthCheckHistoryEntry> list = get().getEntriesList();
-        if (list == null)
-            return null;
-        for (int i = list.size() - 1; i >= 0; i--) {
-            CassandraFrameworkProtos.HealthCheckHistoryEntry hc = list.get(i);
+        CassandraFrameworkProtos.CassandraClusterHealthCheckHistory history = get();
+        int count = history.getEntriesCount();
+        for (int i = count - 1; i >= 0; i--) {
+            CassandraFrameworkProtos.HealthCheckHistoryEntry hc = history.getEntries(i);
             if (executorId.equals(hc.getExecutorId()))
                 return hc;
         }
         return null;
+    }
+
+    public void record(String executorId, long timestamp, @NotNull final CassandraFrameworkProtos.HealthCheckDetails healthCheckDetails) {
+        CassandraFrameworkProtos.CassandraClusterHealthCheckHistory prev = get();
+        int maxEntriesPerNode = prev.getMaxEntriesPerNode();
+        CassandraFrameworkProtos.CassandraClusterHealthCheckHistory.Builder builder =
+            CassandraFrameworkProtos.CassandraClusterHealthCheckHistory.newBuilder()
+                .setMaxEntriesPerNode(maxEntriesPerNode);
+
+        // copy entries from other nodes to new value, collect old entries from current node in temporary list
+        List<CassandraFrameworkProtos.HealthCheckHistoryEntry> forNode = new ArrayList<>(maxEntriesPerNode);
+        for (CassandraFrameworkProtos.HealthCheckHistoryEntry healthCheckHistoryEntry : prev.getEntriesList()) {
+            if (healthCheckHistoryEntry.getExecutorId().equals(executorId)) {
+                forNode.add(healthCheckHistoryEntry);
+            } else {
+                builder.addEntries(healthCheckHistoryEntry);
+            }
+        }
+
+        if (forNode.isEmpty()) {
+            // first history entry, just add it to the builder
+            builder.addEntries(buildEntry(executorId, timestamp, healthCheckDetails));
+        } else {
+            // Check if previous entry is similar to the previous.
+            // If yes, then just update HealthCheckHistoryEntry.timestampLast,
+            // otherwise add the entry and remove the eldest historic entry.
+            CassandraFrameworkProtos.HealthCheckHistoryEntry last = forNode.get(forNode.size() - 1);
+            if (isSimilarEntry(last.getDetails(), healthCheckDetails)) {
+                for (int i = 0; i < forNode.size() - 1; i++) {
+                    builder.addEntries(forNode.get(i));
+                }
+                builder.addEntries(buildEntry(executorId, timestamp, healthCheckDetails)
+                    .setTimestampFirst(last.getTimestampFirst()));
+            } else {
+                for (int i = Math.max(0, forNode.size() + 1 - maxEntriesPerNode); i < forNode.size(); i++)
+                    builder.addEntries(forNode.get(i));
+                builder.addEntries(buildEntry(executorId, timestamp, healthCheckDetails));
+            }
+        }
+
+        setValue(builder.build());
+    }
+
+    static boolean isSimilarEntry(CassandraFrameworkProtos.HealthCheckDetails existing, CassandraFrameworkProtos.HealthCheckDetails current) {
+        for (Descriptors.FieldDescriptor f : existing.getDescriptorForType().getFields()) {
+            if (!"info".equals(f.getName())) {
+                if (!objEquals(existing.getField(f), current.getField(f))) {
+                    return false;
+                }
+            } else {
+                if (!isSimilarEntry(existing.getInfo(), current.getInfo())) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    static boolean isSimilarEntry(CassandraFrameworkProtos.NodeInfo existing, CassandraFrameworkProtos.NodeInfo current) {
+        for (Descriptors.FieldDescriptor f : existing.getDescriptorForType().getFields()) {
+            // ignore 'uptime' field
+            if (!"uptimeMillis".equals(f.getName())) {
+                if (!objEquals(existing.getField(f), current.getField(f))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    static boolean objEquals(Object o1, Object o2) {
+        return o1 == null && o2 == null || !(o1 == null || o2 == null) && o1.equals(o2);
+    }
+
+    private static CassandraFrameworkProtos.HealthCheckHistoryEntry.Builder buildEntry(String executorId, long timestamp,
+           CassandraFrameworkProtos.HealthCheckDetails healthCheckDetails) {
+        return CassandraFrameworkProtos.HealthCheckHistoryEntry.newBuilder()
+            .setExecutorId(executorId)
+            .setTimestampFirst(timestamp)
+            .setTimestampLast(timestamp)
+            .setDetails(healthCheckDetails);
     }
 }

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterHealthCheckHistoryTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterHealthCheckHistoryTest.java
@@ -1,0 +1,412 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+import org.apache.mesos.state.InMemoryState;
+import org.apache.mesos.state.State;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class PersistedCassandraClusterHealthCheckHistoryTest {
+
+    @Test
+    public void testRecord() throws Exception {
+        State state = new InMemoryState();
+        PersistedCassandraClusterHealthCheckHistory hcHistory = new PersistedCassandraClusterHealthCheckHistory(state);
+
+        String exec1 = "exec1";
+
+        CassandraFrameworkProtos.NodeInfo.Builder ni = CassandraFrameworkProtos.NodeInfo.newBuilder()
+            .setClusterName("cluster")
+            .setDataCenter("dc1")
+            .setUptimeMillis(1);
+        CassandraFrameworkProtos.HealthCheckDetails.Builder hc = CassandraFrameworkProtos.HealthCheckDetails.newBuilder()
+            .setHealthy(true)
+            .setInfo(ni.build());
+        hcHistory.record(exec1, 1L, hc.build());
+
+        CassandraFrameworkProtos.HealthCheckHistoryEntry hce1 = hcHistory.last(exec1);
+        assertNotNull(hce1);
+        assertThat(hcHistory.entries())
+            .hasSize(1)
+            .contains(hce1);
+        assertThat(hcHistory.entriesForExecutor(exec1))
+            .hasSize(1)
+            .contains(hce1);
+        assertEquals(1L, hce1.getTimestampFirst());
+        assertEquals(1L, hce1.getTimestampLast());
+
+        // just increase uptime
+        hc.setInfo(ni
+            .setUptimeMillis(2)
+            .build());
+        hcHistory.record(exec1, 2L, hc.build());
+
+        CassandraFrameworkProtos.HealthCheckHistoryEntry hce2 = hcHistory.last(exec1);
+        assertNotNull(hce2);
+        assertThat(hcHistory.entries())
+            .hasSize(1)
+            .contains(hce2);
+        assertThat(hcHistory.entriesForExecutor(exec1))
+            .hasSize(1)
+            .contains(hce2);
+        assertEquals(1L, hce2.getTimestampFirst());
+        assertEquals(2L, hce2.getTimestampLast());
+
+        // toggle a field
+        hc.setInfo(ni
+            .setNativeTransportRunning(true)
+            .build());
+        hcHistory.record(exec1, 3L, hc.build());
+
+        CassandraFrameworkProtos.HealthCheckHistoryEntry hce3 = hcHistory.last(exec1);
+        assertNotNull(hce3);
+        assertThat(hcHistory.entries())
+            .hasSize(2)
+            .contains(hce2)
+            .contains(hce3);
+        assertThat(hcHistory.entriesForExecutor(exec1))
+            .hasSize(2)
+            .contains(hce2)
+            .contains(hce3);
+        assertEquals(3L, hce3.getTimestampFirst());
+        assertEquals(3L, hce3.getTimestampLast());
+
+        // toggle more fields and record
+        hc.setInfo(ni
+            .setNativeTransportRunning(false)
+            .setRpcServerRunning(true)
+            .build());
+        hcHistory.record(exec1, 4L, hc.build());
+        CassandraFrameworkProtos.HealthCheckHistoryEntry hce4 = hcHistory.last(exec1);
+        assertThat(hcHistory.entries()).hasSize(3);
+
+        hc.setInfo(ni
+            .setNativeTransportRunning(true)
+            .setRpcServerRunning(true)
+            .build());
+        hcHistory.record(exec1, 5L, hc.build());
+        CassandraFrameworkProtos.HealthCheckHistoryEntry hce5 = hcHistory.last(exec1);
+        assertThat(hcHistory.entries()).hasSize(4);
+        assertThat(hcHistory.entriesForExecutor(exec1))
+            .hasSize(4)
+            .contains(hce2)
+            .contains(hce3)
+            .contains(hce4)
+            .contains(hce5);
+
+        hc.setHealthy(true)
+            .setMsg("msg");
+        hcHistory.record(exec1, 6L, hc.build());
+        CassandraFrameworkProtos.HealthCheckHistoryEntry hce6 = hcHistory.last(exec1);
+        assertThat(hcHistory.entries()).hasSize(5);
+        assertThat(hcHistory.entriesForExecutor(exec1))
+            .hasSize(5)
+            .contains(hce2)
+            .contains(hce3)
+            .contains(hce4)
+            .contains(hce5)
+            .contains(hce6);
+
+        hc.setHealthy(false)
+            .setMsg("foo");
+        hcHistory.record(exec1, 7L, hc.build());
+        CassandraFrameworkProtos.HealthCheckHistoryEntry hce7 = hcHistory.last(exec1);
+        assertThat(hcHistory.entries()).hasSize(5);
+        assertThat(hcHistory.entriesForExecutor(exec1))
+            .hasSize(5)
+            .doesNotContain(hce2)
+            .contains(hce3)
+            .contains(hce4)
+            .contains(hce5)
+            .contains(hce6)
+            .contains(hce7);
+
+        hc.setHealthy(true)
+            .clearMsg();
+        hcHistory.record(exec1, 8L, hc.build());
+        CassandraFrameworkProtos.HealthCheckHistoryEntry hce8 = hcHistory.last(exec1);
+        assertThat(hcHistory.entries()).hasSize(5);
+        assertThat(hcHistory.entriesForExecutor(exec1))
+            .hasSize(5)
+            .doesNotContain(hce2)
+            .doesNotContain(hce3)
+            .contains(hce4)
+            .contains(hce5)
+            .contains(hce6)
+            .contains(hce7)
+            .contains(hce8);
+
+        //
+        // similar for another executor
+        //
+
+        String exec2 = "exec2";
+
+        CassandraFrameworkProtos.NodeInfo.Builder otherNi = CassandraFrameworkProtos.NodeInfo.newBuilder()
+            .setClusterName("cluster")
+            .setDataCenter("dc1")
+            .setUptimeMillis(1);
+        CassandraFrameworkProtos.HealthCheckDetails.Builder otherHc = CassandraFrameworkProtos.HealthCheckDetails.newBuilder()
+            .setHealthy(true)
+            .setInfo(otherNi.build());
+        hcHistory.record(exec2, 1L, otherHc.build());
+
+        CassandraFrameworkProtos.HealthCheckHistoryEntry otherHce1 = hcHistory.last(exec2);
+        assertNotNull(otherHce1);
+        assertThat(hcHistory.entries())
+            .hasSize(6)
+            .contains(otherHce1)
+            //
+            .doesNotContain(hce2)
+            .doesNotContain(hce3)
+            .contains(hce4)
+            .contains(hce5)
+            .contains(hce6)
+            .contains(hce7)
+            .contains(hce8);
+        assertThat(hcHistory.entriesForExecutor(exec2))
+            .hasSize(1)
+            .contains(otherHce1);
+        assertEquals(1L, otherHce1.getTimestampFirst());
+        assertEquals(1L, otherHce1.getTimestampLast());
+
+        // just increase uptime
+        otherHc.setInfo(otherNi
+            .setUptimeMillis(2)
+            .build());
+        hcHistory.record(exec2, 2L, otherHc.build());
+
+        CassandraFrameworkProtos.HealthCheckHistoryEntry otherHce2 = hcHistory.last(exec2);
+        assertNotNull(otherHce2);
+        assertThat(hcHistory.entries())
+            .hasSize(6)
+            .contains(otherHce2);
+        assertThat(hcHistory.entriesForExecutor(exec2))
+            .hasSize(1)
+            .contains(otherHce2);
+        assertEquals(1L, otherHce2.getTimestampFirst());
+        assertEquals(2L, otherHce2.getTimestampLast());
+
+        // toggle a field
+        otherHc.setInfo(otherNi
+            .setNativeTransportRunning(true)
+            .build());
+        hcHistory.record(exec2, 3L, otherHc.build());
+
+        CassandraFrameworkProtos.HealthCheckHistoryEntry otherHce3 = hcHistory.last(exec2);
+        assertNotNull(otherHce3);
+        assertThat(hcHistory.entries())
+            .hasSize(7)
+            .contains(otherHce2)
+            .contains(otherHce3);
+        assertThat(hcHistory.entriesForExecutor(exec2))
+            .hasSize(2)
+            .contains(otherHce2)
+            .contains(otherHce3);
+        assertEquals(3L, otherHce3.getTimestampFirst());
+        assertEquals(3L, otherHce3.getTimestampLast());
+
+        // toggle more fields and record
+        otherHc.setInfo(otherNi
+            .setNativeTransportRunning(false)
+            .setRpcServerRunning(true)
+            .build());
+        hcHistory.record(exec2, 4L, otherHc.build());
+        CassandraFrameworkProtos.HealthCheckHistoryEntry otherHce4 = hcHistory.last(exec2);
+        assertThat(hcHistory.entries()).hasSize(8);
+
+        otherHc.setInfo(otherNi
+            .setNativeTransportRunning(true)
+            .setRpcServerRunning(true)
+            .build());
+        hcHistory.record(exec2, 5L, otherHc.build());
+        CassandraFrameworkProtos.HealthCheckHistoryEntry otherHce5 = hcHistory.last(exec2);
+        assertThat(hcHistory.entries()).hasSize(9);
+        assertThat(hcHistory.entriesForExecutor(exec2))
+            .hasSize(4)
+            .contains(otherHce2)
+            .contains(otherHce3)
+            .contains(otherHce4)
+            .contains(otherHce5);
+
+        otherHc.setHealthy(true)
+            .setMsg("msg");
+        hcHistory.record(exec2, 6L, otherHc.build());
+        CassandraFrameworkProtos.HealthCheckHistoryEntry otherHce6 = hcHistory.last(exec2);
+        assertThat(hcHistory.entries()).hasSize(10);
+        assertThat(hcHistory.entriesForExecutor(exec2))
+            .hasSize(5)
+            .contains(otherHce2)
+            .contains(otherHce3)
+            .contains(otherHce4)
+            .contains(otherHce5)
+            .contains(otherHce6);
+
+        otherHc.setHealthy(false)
+            .setMsg("foo");
+        hcHistory.record(exec2, 7L, otherHc.build());
+        CassandraFrameworkProtos.HealthCheckHistoryEntry otherHce7 = hcHistory.last(exec2);
+        assertThat(hcHistory.entries()).hasSize(10);
+        assertThat(hcHistory.entriesForExecutor(exec2))
+            .hasSize(5)
+            .doesNotContain(otherHce2)
+            .contains(otherHce3)
+            .contains(otherHce4)
+            .contains(otherHce5)
+            .contains(otherHce6)
+            .contains(otherHce7);
+
+        otherHc.setHealthy(true)
+            .clearMsg();
+        hcHistory.record(exec2, 8L, otherHc.build());
+        CassandraFrameworkProtos.HealthCheckHistoryEntry otherHce8 = hcHistory.last(exec2);
+        assertThat(hcHistory.entries())
+            .hasSize(10)
+            //
+            .doesNotContain(otherHce2)
+            .doesNotContain(otherHce3)
+            .contains(otherHce4)
+            .contains(otherHce5)
+            .contains(otherHce6)
+            .contains(otherHce7)
+            .contains(otherHce8)
+            //
+            .doesNotContain(hce2)
+            .doesNotContain(hce3)
+            .contains(hce4)
+            .contains(hce5)
+            .contains(hce6)
+            .contains(hce7)
+            .contains(hce8);
+        assertThat(hcHistory.entriesForExecutor(exec2))
+            .hasSize(5)
+            .doesNotContain(otherHce2)
+            .doesNotContain(otherHce3)
+            .contains(otherHce4)
+            .contains(otherHce5)
+            .contains(otherHce6)
+            .contains(otherHce7)
+            .contains(otherHce8);
+
+    }
+
+    @Test
+    public void testIsSimilarEntryHealthCheckDetails() throws Exception {
+        CassandraFrameworkProtos.HealthCheckDetails.Builder hc1 = CassandraFrameworkProtos.HealthCheckDetails.newBuilder();
+        CassandraFrameworkProtos.HealthCheckDetails.Builder hc2 = CassandraFrameworkProtos.HealthCheckDetails.newBuilder();
+
+        CassandraFrameworkProtos.NodeInfo.Builder ni1 = CassandraFrameworkProtos.NodeInfo.newBuilder();
+        CassandraFrameworkProtos.NodeInfo.Builder ni2 = CassandraFrameworkProtos.NodeInfo.newBuilder();
+
+        hc1.setHealthy(true);
+        hc2.setHealthy(true);
+
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(hc1.build(), hc2.build()));
+
+        hc1.setInfo(ni1);
+        hc2.setInfo(ni2);
+
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(hc1.build(), hc2.build()));
+
+        ni1.setUptimeMillis(1234);
+        ni2.setUptimeMillis(5678);
+        ni1.setClusterName("cluster");
+        ni2.setClusterName("cluster");
+        ni1.setNativeTransportRunning(true);
+        ni2.setNativeTransportRunning(true);
+        hc1.setInfo(ni1);
+        hc2.setInfo(ni2);
+
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(hc1.build(), hc2.build()));
+
+        ni2.setNativeTransportRunning(false);
+        hc2.setInfo(ni2);
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(hc1.build(), hc2.build()));
+
+        ni2.setNativeTransportRunning(true);
+        ni2.setClusterName("foo");
+        hc2.setInfo(ni2);
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(hc1.build(), hc2.build()));
+
+        ni2.setClusterName("cluster");
+        hc2.setInfo(ni2);
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(hc1.build(), hc2.build()));
+
+        hc2.setHealthy(false);
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(hc1.build(), hc2.build()));
+
+        hc2.setHealthy(true);
+        hc2.setMsg("msg");
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(hc1.build(), hc2.build()));
+
+        hc2.clearMsg();
+        hc1.setMsg("msg");
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(hc1.build(), hc2.build()));
+
+        hc1.clearMsg();
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(hc1.build(), hc2.build()));
+
+    }
+
+    @Test
+    public void testIsSimilarEntryNodeInfo() throws Exception {
+        CassandraFrameworkProtos.NodeInfo.Builder ni1 = CassandraFrameworkProtos.NodeInfo.newBuilder();
+        CassandraFrameworkProtos.NodeInfo.Builder ni2 = CassandraFrameworkProtos.NodeInfo.newBuilder();
+
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(ni1.build(), ni2.build()));
+        ni1.setUptimeMillis(1234);
+        ni2.setUptimeMillis(5678);
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(ni1.build(), ni2.build()));
+
+        ni1.setClusterName("cluster");
+        ni2.setClusterName("cluster");
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(ni1.build(), ni2.build()));
+
+        ni1.setNativeTransportRunning(true);
+        ni2.setNativeTransportRunning(true);
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(ni1.build(), ni2.build()));
+
+        ni2.setNativeTransportRunning(false);
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(ni1.build(), ni2.build()));
+
+        ni2.setNativeTransportRunning(true);
+        ni2.setClusterName("foo");
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(ni1.build(), ni2.build()));
+
+        ni2.setNativeTransportRunning(true);
+        ni2.setClusterName("cluster");
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(ni1.build(), ni2.build()));
+
+        ni1.setDataCenter("dc");
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(ni1.build(), ni2.build()));
+
+        ni1.clearDataCenter();
+        ni2.setRack("rac");
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.isSimilarEntry(ni1.build(), ni2.build()));
+    }
+
+    @Test
+    public void testObjEquals() throws Exception {
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.objEquals(null, null));
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.objEquals(null, ""));
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.objEquals("", null));
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.objEquals("1", "1"));
+        assertTrue(PersistedCassandraClusterHealthCheckHistory.objEquals(1, 1));
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.objEquals("1", "2"));
+        assertFalse(PersistedCassandraClusterHealthCheckHistory.objEquals(1, 2));
+    }
+}


### PR DESCRIPTION
Limit health check history to N _different_ health check results.
That is - only changes of the `HealthCheckDetails` and `NodeInfo` will be recorded (plus _first_ and _last_ timestamp of occurence).
The `uptimeMillis` field is ignored in change-detection.

TBH I think we should use separate objects in state for each node/executor. But we should do that in a separate PR. We can also merge HC history into `CassandraNode` since `CassandraNode` is also updated on every HC.

This PR is independent from other PRs.