### PR TITLE
Add API to inquire live nodes by clients

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -233,3 +233,58 @@ JRE_FILE_PATH=${PROJECT_DIR}/target/framework-package/jdk.tar.gz
 CASSANDRA_FILE_PATH=${PROJECT_DIR}/target/framework-package/cassandra.tar.gz
 
 ```
+
+## Using Cassandra tools
+
+You can use standard command line tools delivered with Apache Cassandra against clusters running on
+Apache Mesos.
+
+This framework provides API endpoints for most tools. All you need is `curl` and the hostname/IP of
+the node running the scheduler of this framework.
+
+An example how to invoke `nodetool`:
+
+```
+cassandra/2.1/bin/nodetool `curl -s http://192.168.5.101:18080/live-nodes/nodetool` status
+Datacenter: datacenter1
+=======================
+Status=Up/Down
+|/ State=Normal/Leaving/Joining/Moving
+--  Address    Load       Tokens  Owns (effective)  Host ID                               Rack
+UN  127.0.0.1  41,12 KB   256     100,0%            dc04253f-d878-4d44-acf3-dc014e058b03  rack1
+UN  127.0.0.2  55,51 KB   256     100,0%            685e82e9-fa26-4d12-bee3-13d4f823f5c9  rack1
+```
+
+More examples (note that you have to adjust the path `cassandra/2.1` to where your Apache Cassandra
+distribution lives):
+
+```
+cassandra/2.1/bin/cqlsh `curl -s http://192.168.5.101:18080/live-nodes/cqlsh`
+cassandra/2.1/bin/nodetool `curl -s http://192.168.5.101:18080/live-nodes/nodetool` status
+cassandra/2.1/tools/bin/cassandra-stress read `curl -s http://192.168.5.101:18080/live-nodes/stress`
+```
+
+There are also two endpoints - one returns a simple JSON structure and one just plain ASCII with the native port
+in the first line and node IP addresses on each following line. The number as the last part of the path determines
+the number of nodes you'd like to have.
+
+Example for `json` endpoint:
+```
+curl -s http://192.168.5.101:18080/live-nodes/json/2
+{
+  "nativePort" : 9042,
+  "rpcPort" : 9160,
+  "jmxPort" : 7199,
+  "liveNodes" : [ "127.0.0.2", "127.0.0.1" ]
+}
+```
+
+Example for `ascii` endpoint:
+```
+curl -s http://192.168.5.101:18080/live-nodes/ascii/2
+9042
+127.0.0.1
+127.0.0.2
+```
+
+Note that the implementation does a best-effort approach to return random nodes.

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -27,6 +27,7 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.util.List;
 
 @Path("/")
 public final class ApiController {
@@ -301,6 +302,94 @@ public final class ApiController {
         }
         else
             json.writeNullField(name);
+    }
+
+    @GET
+    @Path("/live-nodes/{forTool}")
+    public Response liveEndpoints(@PathParam("forTool") String forTool) {
+        return liveEndpoints(forTool, 1);
+    }
+
+    @GET
+    @Path("/live-nodes/{forTool}/{nodeCount}")
+    public Response liveEndpoints(@PathParam("forTool") String forTool, @PathParam("nodeCount") Integer nodeCount) {
+        List<CassandraFrameworkProtos.CassandraNode> liveNodes = cluster.liveNodes(nodeCount);
+
+        if (liveNodes.isEmpty())
+            return Response.status(400).build();
+
+        CassandraFrameworkProtos.CassandraFrameworkConfiguration configuration = cluster.getConfiguration().get();
+
+        int nativePort = CassandraCluster.getPortMapping(configuration, CassandraCluster.PORT_NATIVE);
+        int rpcPort = CassandraCluster.getPortMapping(configuration, CassandraCluster.PORT_RPC);
+        int jmxPort = CassandraCluster.getPortMapping(configuration, CassandraCluster.PORT_JMX);
+
+        CassandraFrameworkProtos.CassandraNode first = liveNodes.get(0);
+
+        StringWriter sw = new StringWriter();
+        try {
+            switch (forTool) {
+                case "cqlsh":
+                    // return a string: "HOST PORT"
+                    return Response.ok(first.getIp() + ' ' + nativePort, "text/plain").build();
+                case "stress":
+                    // cassandra-stress options:
+                    // -node NODE1,NODE2,...
+                    // -port [native=NATIVE_PORT] [thrift=THRIFT_PORT] [jmx=JMX_PORT]
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("-node ");
+                    for (int i = 0; i < liveNodes.size(); i++) {
+                        if (i > 0)
+                            sb.append(',');
+                        sb.append(liveNodes.get(i).getIp());
+                    }
+                    sb.append(" -port native=")
+                        .append(nativePort)
+                        .append(" thrift=")
+                        .append(rpcPort)
+                        .append(" jmx=")
+                        .append(jmxPort);
+                    return Response.ok(sb.toString(), "text/plain").build();
+                case "nodetool":
+                    // nodetool options:
+                    // -h HOST
+                    // -p JMX_PORT
+                    return Response.ok("-h " + first.getIp() + " -p " + first.getJmxConnect().getJmxPort(), "text/plain").build();
+                case "json":
+                    // produce a simple JSON with the native port and live node IPs
+                    JsonFactory factory = new JsonFactory();
+                    JsonGenerator json = factory.createGenerator(sw);
+                    json.setPrettyPrinter(new DefaultPrettyPrinter());
+                    json.writeStartObject();
+
+                    json.writeNumberField("nativePort", nativePort);
+                    json.writeNumberField("rpcPort", rpcPort);
+                    json.writeNumberField("jmxPort", jmxPort);
+
+                    json.writeArrayFieldStart("liveNodes");
+                    for (CassandraFrameworkProtos.CassandraNode liveNode : liveNodes) {
+                        json.writeString(liveNode.getIp());
+                    }
+                    json.writeEndArray();
+
+                    json.writeEndObject();
+                    json.close();
+                    return Response.ok(sw.toString(), "application/json").build();
+                case "ascii":
+                    // produce a simple text with the native port in the first line and one line per live node IP
+                    sb = new StringBuilder();
+                    sb.append(nativePort).append('\n');
+                    for (CassandraFrameworkProtos.CassandraNode liveNode : liveNodes) {
+                        sb.append(liveNode.getIp()).append('\n');
+                    }
+                    return Response.ok(sb.toString(), "text/plain").build();
+            }
+
+            return Response.status(404).build();
+        } catch (Exception e) {
+            LOGGER.error("Failed to all nodes list", e);
+            return Response.serverError().build();
+        }
     }
 
     // cluster scaling

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -931,7 +931,7 @@ public final class CassandraCluster {
         }
     }
 
-    public List<CassandraNode> liveNodes(int nodeCount) {
+    public List<CassandraNode> liveNodes(int limit) {
         CassandraClusterState state = clusterState.get();
         int total = state.getNodesCount();
         if (total == 0)
@@ -943,12 +943,12 @@ public final class CassandraCluster {
                 totalLive++;
         }
 
-        nodeCount = Math.min(totalLive, nodeCount);
+        limit = Math.min(totalLive, limit);
 
         ThreadLocalRandom tlr = ThreadLocalRandom.current();
-        List<CassandraNode> result = new ArrayList<>(nodeCount);
+        List<CassandraNode> result = new ArrayList<>(limit);
         int misses = 0;
-        while (result.size() < nodeCount && misses < 250) { // the check for 250 misses is a poor-man's implementation to prevent a possible race-condition
+        while (result.size() < limit && misses < 250) { // the check for 250 misses is a poor-man's implementation to prevent a possible race-condition
             int i = tlr.nextInt(total);
             CassandraNode node = state.getNodes(i);
             if (isLiveNode(node) && !result.contains(node)) {

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -36,6 +36,7 @@ import java.net.InetAddress;
 import java.net.ServerSocket;
 import java.net.UnknownHostException;
 import java.util.*;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.regex.Pattern;
 
 import static com.google.common.base.Predicates.not;
@@ -928,5 +929,51 @@ public final class CassandraCluster {
                 .setCassandraDaemonPid(cassandraServerRunMetadata.getPid())
                 .build());
         }
+    }
+
+    public List<CassandraNode> liveNodes(int nodeCount) {
+        CassandraClusterState state = clusterState.get();
+        int total = state.getNodesCount();
+        if (total == 0)
+            return Collections.emptyList();
+
+        int totalLive = 0;
+        for (int i = 0; i < total; i++) {
+            if (isLiveNode(state.getNodes(i)))
+                totalLive++;
+        }
+
+        nodeCount = Math.min(totalLive, nodeCount);
+
+        ThreadLocalRandom tlr = ThreadLocalRandom.current();
+        List<CassandraNode> result = new ArrayList<>(nodeCount);
+        int misses = 0;
+        while (result.size() < nodeCount && misses < 250) { // the check for 250 misses is a poor-man's implementation to prevent a possible race-condition
+            int i = tlr.nextInt(total);
+            CassandraNode node = state.getNodes(i);
+            if (isLiveNode(node) && !result.contains(node)) {
+                result.add(node);
+                misses = 0;
+            } else {
+                misses ++;
+            }
+        }
+
+        return result;
+    }
+
+    private boolean isLiveNode(CassandraNode node) {
+        if (!node.hasCassandraNodeExecutor())
+            return false;
+        HealthCheckHistoryEntry hc = lastHealthCheck(node.getCassandraNodeExecutor().getExecutorId());
+        if (hc == null || !hc.hasDetails())
+            return false;
+        HealthCheckDetails hcd = hc.getDetails();
+        if (!hcd.getHealthy() || !hcd.hasInfo())
+            return false;
+        NodeInfo info = hcd.getInfo();
+        if (!info.hasNativeTransportRunning() || !info.hasRpcServerRunning())
+            return false;
+        return info.getNativeTransportRunning() && info.getRpcServerRunning();
     }
 }

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractSchedulerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractSchedulerTest.java
@@ -118,6 +118,8 @@ public abstract class AbstractSchedulerTest {
                         .setOperationMode(operationMode)
                         .setUptimeMillis(1234)
                         .setVersion("2.1.2")
+                        .setNativeTransportRunning(true)
+                        .setRpcServerRunning(true)
                 )
                 .build();
     }

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
@@ -1,0 +1,346 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import com.fasterxml.jackson.databind.node.MissingNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.databind.node.TextNode;
+import io.mesosphere.mesos.util.Tuple2;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.Assert.*;
+
+public class ApiControllerTest extends AbstractSchedulerTest {
+    private URI httpServerBaseUri;
+    private HttpServer httpServer;
+
+    @Test
+    public void testRoot() throws Exception {
+        Tuple2<Integer, JsonNode> tup = fetchJson("/");
+        assertEquals(200, tup._1.intValue());
+        JsonNode json = tup._2;
+
+        assertEquals(resolve("/config").toString(), json.get("configuration").asText());
+        assertEquals(resolve("/nodes").toString(), json.get("allNodes").asText());
+        assertThat(json.get("repair")).isInstanceOf(ObjectNode.class);
+        assertThat(json.get("cleanup")).isInstanceOf(ObjectNode.class);
+    }
+
+    @Test
+    public void testConfig() throws Exception {
+        Tuple2<Integer, JsonNode> tup = fetchJson("/config");
+        assertEquals(200, tup._1.intValue());
+        JsonNode json = tup._2;
+
+        assertEquals("test-cluster", json.get("frameworkName").asText());
+        assertEquals("", json.get("frameworkId").asText());
+        assertEquals(3, json.get("numberOfNodes").asInt());
+        assertEquals(2, json.get("numberOfSeeds").asInt());
+        assertEquals(9042, json.get("nativePort").asInt());
+        assertEquals(9160, json.get("rpcPort").asInt());
+    }
+
+    @Test
+    public void testNodes() throws Exception {
+        Tuple2<Integer, JsonNode> tup = fetchJson("/nodes");
+        assertEquals(200, tup._1.intValue());
+        JsonNode json = tup._2;
+
+        assertTrue(json.has("nodes"));
+    }
+
+    @Test
+    public void testLiveNodes() throws Exception {
+        Tuple2<Integer, JsonNode> tup = fetchJson("/live-nodes/json/2");
+
+        // must return HTTP/500 if no nodes are present
+        assertEquals(400, tup._1.intValue());
+
+        // add one live node
+        addNode("exec1", "1.2.3.4");
+
+        tup = fetchJson("/live-nodes/json/2");
+        assertEquals(200, tup._1.intValue());
+        JsonNode json = tup._2;
+        assertEquals(9042, json.get("nativePort").asInt());
+        assertEquals(9160, json.get("rpcPort").asInt());
+        assertEquals(7199, json.get("jmxPort").asInt());
+        JsonNode nodes = json.get("liveNodes");
+        assertEquals(JsonNodeType.ARRAY, nodes.getNodeType());
+        assertThat(nodes)
+            .hasSize(1)
+            .contains(TextNode.valueOf("1.2.3.4"));
+
+        // test more output formats
+
+        Tuple2<Integer, String> str = fetchText("/live-nodes/cqlsh/2");
+        assertEquals(200, str._1.intValue());
+        assertEquals("1.2.3.4 9042", str._2);
+
+        str = fetchText("/live-nodes/stress/2");
+        assertEquals(200, str._1.intValue());
+        assertEquals("-node 1.2.3.4 -port native=9042 thrift=9160 jmx=7199", str._2);
+
+        str = fetchText("/live-nodes/nodetool/2");
+        assertEquals(200, str._1.intValue());
+        assertEquals("-h 1.2.3.4 -p 7199", str._2);
+
+        str = fetchText("/live-nodes/ascii/2");
+        assertEquals(200, str._1.intValue());
+        assertEquals("9042\n1.2.3.4\n", str._2);
+
+        str = fetchText("/live-nodes/cqlsh");
+        assertEquals(200, str._1.intValue());
+        assertEquals("1.2.3.4 9042", str._2);
+
+        str = fetchText("/live-nodes/stress");
+        assertEquals(200, str._1.intValue());
+        assertEquals("-node 1.2.3.4 -port native=9042 thrift=9160 jmx=7199", str._2);
+
+        str = fetchText("/live-nodes/nodetool");
+        assertEquals(200, str._1.intValue());
+        assertEquals("-h 1.2.3.4 -p 7199", str._2);
+
+        str = fetchText("/live-nodes/ascii");
+        assertEquals(200, str._1.intValue());
+        assertEquals("9042\n1.2.3.4\n", str._2);
+
+        //
+        // mark node as dead
+        //
+
+        cluster.recordHealthCheck("exec1", healthCheckDetailsFailed());
+        tup = fetchJson("/live-nodes/json/2");
+        assertEquals(400, tup._1.intValue());
+
+        str = fetchText("/live-nodes/cqlsh/2");
+        assertEquals(400, str._1.intValue());
+
+        str = fetchText("/live-nodes/stress/2");
+        assertEquals(400, str._1.intValue());
+
+        str = fetchText("/live-nodes/nodetool/2");
+        assertEquals(400, str._1.intValue());
+
+        str = fetchText("/live-nodes/ascii/2");
+        assertEquals(400, str._1.intValue());
+
+        // add a live nodes
+
+        addNode("exec2", "2.2.2.2");
+
+        tup = fetchJson("/live-nodes/json/2");
+        assertEquals(200, tup._1.intValue());
+        json = tup._2;
+        assertEquals(9042, json.get("nativePort").asInt());
+        assertEquals(9160, json.get("rpcPort").asInt());
+        assertEquals(7199, json.get("jmxPort").asInt());
+        nodes = json.get("liveNodes");
+        assertEquals(JsonNodeType.ARRAY, nodes.getNodeType());
+        assertThat(nodes)
+            .hasSize(1)
+            .contains(TextNode.valueOf("2.2.2.2"));
+
+        str = fetchText("/live-nodes/cqlsh/2");
+        assertEquals(200, str._1.intValue());
+        assertEquals("2.2.2.2 9042", str._2);
+
+        str = fetchText("/live-nodes/stress/2");
+        assertEquals(200, str._1.intValue());
+        assertEquals("-node 2.2.2.2 -port native=9042 thrift=9160 jmx=7199", str._2);
+
+        str = fetchText("/live-nodes/nodetool/2");
+        assertEquals(200, str._1.intValue());
+        assertEquals("-h 2.2.2.2 -p 7199", str._2);
+
+        str = fetchText("/live-nodes/ascii/2");
+        assertEquals(200, str._1.intValue());
+        assertEquals("9042\n2.2.2.2\n", str._2);
+
+        // mark 1st node as live
+
+        cluster.recordHealthCheck("exec1", healthCheckDetailsSuccess("NORMAL", true));
+
+        tup = fetchJson("/live-nodes/json/2");
+        assertEquals(200, tup._1.intValue());
+        json = tup._2;
+        assertEquals(9042, json.get("nativePort").asInt());
+        assertEquals(9160, json.get("rpcPort").asInt());
+        assertEquals(7199, json.get("jmxPort").asInt());
+        nodes = json.get("liveNodes");
+        assertEquals(JsonNodeType.ARRAY, nodes.getNodeType());
+        assertThat(nodes)
+            .hasSize(2)
+            .contains(TextNode.valueOf("1.2.3.4"))
+            .contains(TextNode.valueOf("2.2.2.2"));
+
+        str = fetchText("/live-nodes/cqlsh/2");
+        assertEquals(200, str._1.intValue());
+
+        str = fetchText("/live-nodes/stress/2");
+        assertEquals(200, str._1.intValue());
+
+        str = fetchText("/live-nodes/nodetool/2");
+        assertEquals(200, str._1.intValue());
+
+        str = fetchText("/live-nodes/ascii/2");
+        assertEquals(200, str._1.intValue());
+    }
+
+    private void addNode(String executorId, String ip) {
+        cluster.getClusterState().addOrSetNode(CassandraFrameworkProtos.CassandraNode.newBuilder()
+            .setCassandraNodeExecutor(
+                CassandraFrameworkProtos.CassandraNodeExecutor.newBuilder(CassandraFrameworkProtos.CassandraNodeExecutor.getDefaultInstance())
+                    .setExecutorId(executorId)
+                    .setSource("source")
+                    .setCpuCores(1)
+                    .setMemMb(1)
+                    .setDiskMb(1)
+                    .setCommand("comand")
+            )
+            .setHostname(ip)
+            .setIp(ip)
+            .setSeed(false)
+            .setJmxConnect(CassandraFrameworkProtos.JmxConnect.newBuilder()
+                .setIp(ip)
+                .setJmxPort(7199))
+            .build());
+        cluster.recordHealthCheck(executorId, healthCheckDetailsSuccess("NORMAL", true));
+    }
+
+    @Test
+    public void testNonExistingUri() throws Exception {
+        Tuple2<Integer, JsonNode> tup = fetchJson("/does-not-exist");
+        assertEquals(404, tup._1.intValue());
+    }
+
+    private Tuple2<Integer, JsonNode> fetchJson(String rel) throws Exception {
+        JsonFactory factory = new JsonFactory();
+        HttpURLConnection conn = (HttpURLConnection) resolve(rel).toURL().openConnection();
+        try {
+            conn.connect();
+
+            int responseCode = conn.getResponseCode();
+
+            InputStream in;
+            try {
+                in = conn.getInputStream();
+            } catch (IOException e) {
+                in = conn.getErrorStream();
+            }
+            if (in == null) {
+                return Tuple2.tuple2(responseCode, (JsonNode) MissingNode.getInstance());
+            }
+            try {
+                ObjectMapper om = new ObjectMapper();
+                return Tuple2.tuple2(responseCode, om.reader()
+                    .with(factory)
+                    .readTree(in));
+            } finally {
+                in.close();
+            }
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    private Tuple2<Integer, String> fetchText(String rel) throws Exception {
+        HttpURLConnection conn = (HttpURLConnection) resolve(rel).toURL().openConnection();
+        try {
+            conn.connect();
+
+            int responseCode = conn.getResponseCode();
+
+            InputStream in;
+            try {
+                in = conn.getInputStream();
+            } catch (IOException e) {
+                in = conn.getErrorStream();
+            }
+            if (in == null) {
+                return Tuple2.tuple2(responseCode, "");
+            }
+            try {
+                StringBuilder sb = new StringBuilder();
+                int rd;
+                while ((rd = in.read()) != -1)
+                    sb.append((char) rd);
+                return Tuple2.tuple2(responseCode, sb.toString());
+            } finally {
+                in.close();
+            }
+        } finally {
+            conn.disconnect();
+        }
+    }
+
+    @NotNull
+    private URI resolve(String rel) {
+        return httpServerBaseUri.resolve(rel);
+    }
+
+    @Before
+    public void cleanState() {
+        super.cleanState();
+
+        try {
+            try (ServerSocket sock = new ServerSocket(0)) {
+                httpServerBaseUri = URI.create(String.format("http://%s:%d/", formatInetAddress(InetAddress.getLocalHost()), sock.getLocalPort()));
+            }
+
+            final ResourceConfig rc = new ResourceConfig()
+                .register(new ApiController(cluster));
+            httpServer = GrizzlyHttpServerFactory.createHttpServer(httpServerBaseUri, rc);
+            httpServer.start();
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @After
+    public void cleanup() {
+        if (httpServer != null)
+            httpServer.shutdown();
+    }
+
+    @NotNull
+    private static String formatInetAddress(@NotNull final InetAddress inetAddress) {
+        if (inetAddress instanceof Inet4Address) {
+            final Inet4Address address = (Inet4Address) inetAddress;
+            return address.getHostAddress();
+        } else if (inetAddress instanceof Inet6Address) {
+            final Inet6Address address = (Inet6Address) inetAddress;
+            return String.format("[%s]", address.getHostAddress());
+        } else {
+            throw new IllegalArgumentException("InetAddress type: " + inetAddress.getClass().getName() + " is not supported");
+        }
+    }
+
+}

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
@@ -60,8 +60,6 @@ public class ApiControllerTest extends AbstractSchedulerTest {
 
         assertEquals("test-cluster", json.get("frameworkName").asText());
         assertEquals("", json.get("frameworkId").asText());
-        assertEquals(3, json.get("numberOfNodes").asInt());
-        assertEquals(2, json.get("numberOfSeeds").asInt());
         assertEquals(9042, json.get("nativePort").asInt());
         assertEquals(9160, json.get("rpcPort").asInt());
     }
@@ -77,7 +75,7 @@ public class ApiControllerTest extends AbstractSchedulerTest {
 
     @Test
     public void testLiveNodes() throws Exception {
-        Tuple2<Integer, JsonNode> tup = fetchJson("/live-nodes/json/2");
+        Tuple2<Integer, JsonNode> tup = fetchJson("/live-nodes?limit=2");
 
         // must return HTTP/500 if no nodes are present
         assertEquals(400, tup._1.intValue());
@@ -85,7 +83,7 @@ public class ApiControllerTest extends AbstractSchedulerTest {
         // add one live node
         addNode("exec1", "1.2.3.4");
 
-        tup = fetchJson("/live-nodes/json/2");
+        tup = fetchJson("/live-nodes?limit=2");
         assertEquals(200, tup._1.intValue());
         JsonNode json = tup._2;
         assertEquals(9042, json.get("nativePort").asInt());
@@ -99,35 +97,35 @@ public class ApiControllerTest extends AbstractSchedulerTest {
 
         // test more output formats
 
-        Tuple2<Integer, String> str = fetchText("/live-nodes/cqlsh/2");
+        Tuple2<Integer, String> str = fetchText("/live-nodes/cqlsh", "text/x-cassandra-cqlsh");
         assertEquals(200, str._1.intValue());
         assertEquals("1.2.3.4 9042", str._2);
 
-        str = fetchText("/live-nodes/stress/2");
+        str = fetchText("/live-nodes/stress?limit=2", "text/x-cassandra-stress");
         assertEquals(200, str._1.intValue());
         assertEquals("-node 1.2.3.4 -port native=9042 thrift=9160 jmx=7199", str._2);
 
-        str = fetchText("/live-nodes/nodetool/2");
+        str = fetchText("/live-nodes/nodetool", "text/x-cassandra-nodetool");
         assertEquals(200, str._1.intValue());
         assertEquals("-h 1.2.3.4 -p 7199", str._2);
 
-        str = fetchText("/live-nodes/ascii/2");
+        str = fetchText("/live-nodes/text?limit=2", "text/plain");
         assertEquals(200, str._1.intValue());
         assertEquals("9042\n1.2.3.4\n", str._2);
 
-        str = fetchText("/live-nodes/cqlsh");
+        str = fetchText("/live-nodes/cqlsh", "text/x-cassandra-cqlsh");
         assertEquals(200, str._1.intValue());
         assertEquals("1.2.3.4 9042", str._2);
 
-        str = fetchText("/live-nodes/stress");
+        str = fetchText("/live-nodes/stress", "text/x-cassandra-stress");
         assertEquals(200, str._1.intValue());
         assertEquals("-node 1.2.3.4 -port native=9042 thrift=9160 jmx=7199", str._2);
 
-        str = fetchText("/live-nodes/nodetool");
+        str = fetchText("/live-nodes/nodetool", "text/x-cassandra-nodetool");
         assertEquals(200, str._1.intValue());
         assertEquals("-h 1.2.3.4 -p 7199", str._2);
 
-        str = fetchText("/live-nodes/ascii");
+        str = fetchText("/live-nodes/text", "text/plain");
         assertEquals(200, str._1.intValue());
         assertEquals("9042\n1.2.3.4\n", str._2);
 
@@ -136,26 +134,26 @@ public class ApiControllerTest extends AbstractSchedulerTest {
         //
 
         cluster.recordHealthCheck("exec1", healthCheckDetailsFailed());
-        tup = fetchJson("/live-nodes/json/2");
+        tup = fetchJson("/live-nodes?limit=2");
         assertEquals(400, tup._1.intValue());
 
-        str = fetchText("/live-nodes/cqlsh/2");
+        str = fetchText("/live-nodes/cqlsh", "text/x-cassandra-cqlsh");
         assertEquals(400, str._1.intValue());
 
-        str = fetchText("/live-nodes/stress/2");
+        str = fetchText("/live-nodes/stress?limit=2", "text/x-cassandra-stress");
         assertEquals(400, str._1.intValue());
 
-        str = fetchText("/live-nodes/nodetool/2");
+        str = fetchText("/live-nodes/nodetool", "text/x-cassandra-nodetool");
         assertEquals(400, str._1.intValue());
 
-        str = fetchText("/live-nodes/ascii/2");
+        str = fetchText("/live-nodes/text?limit=2", "text/plain");
         assertEquals(400, str._1.intValue());
 
         // add a live nodes
 
         addNode("exec2", "2.2.2.2");
 
-        tup = fetchJson("/live-nodes/json/2");
+        tup = fetchJson("/live-nodes?limit=2");
         assertEquals(200, tup._1.intValue());
         json = tup._2;
         assertEquals(9042, json.get("nativePort").asInt());
@@ -167,19 +165,19 @@ public class ApiControllerTest extends AbstractSchedulerTest {
             .hasSize(1)
             .contains(TextNode.valueOf("2.2.2.2"));
 
-        str = fetchText("/live-nodes/cqlsh/2");
+        str = fetchText("/live-nodes/cqlsh", "text/x-cassandra-cqlsh");
         assertEquals(200, str._1.intValue());
         assertEquals("2.2.2.2 9042", str._2);
 
-        str = fetchText("/live-nodes/stress/2");
+        str = fetchText("/live-nodes/stress?limit=2", "text/x-cassandra-stress");
         assertEquals(200, str._1.intValue());
         assertEquals("-node 2.2.2.2 -port native=9042 thrift=9160 jmx=7199", str._2);
 
-        str = fetchText("/live-nodes/nodetool/2");
+        str = fetchText("/live-nodes/nodetool", "text/x-cassandra-nodetool");
         assertEquals(200, str._1.intValue());
         assertEquals("-h 2.2.2.2 -p 7199", str._2);
 
-        str = fetchText("/live-nodes/ascii/2");
+        str = fetchText("/live-nodes/text?limit=2", "text/plain");
         assertEquals(200, str._1.intValue());
         assertEquals("9042\n2.2.2.2\n", str._2);
 
@@ -187,7 +185,7 @@ public class ApiControllerTest extends AbstractSchedulerTest {
 
         cluster.recordHealthCheck("exec1", healthCheckDetailsSuccess("NORMAL", true));
 
-        tup = fetchJson("/live-nodes/json/2");
+        tup = fetchJson("/live-nodes?limit=2");
         assertEquals(200, tup._1.intValue());
         json = tup._2;
         assertEquals(9042, json.get("nativePort").asInt());
@@ -200,16 +198,16 @@ public class ApiControllerTest extends AbstractSchedulerTest {
             .contains(TextNode.valueOf("1.2.3.4"))
             .contains(TextNode.valueOf("2.2.2.2"));
 
-        str = fetchText("/live-nodes/cqlsh/2");
+        str = fetchText("/live-nodes/cqlsh", "text/x-cassandra-cqlsh");
         assertEquals(200, str._1.intValue());
 
-        str = fetchText("/live-nodes/stress/2");
+        str = fetchText("/live-nodes/stress?limit=2", "text/x-cassandra-stress");
         assertEquals(200, str._1.intValue());
 
-        str = fetchText("/live-nodes/nodetool/2");
+        str = fetchText("/live-nodes/nodetool", "text/x-cassandra-nodetool");
         assertEquals(200, str._1.intValue());
 
-        str = fetchText("/live-nodes/ascii/2");
+        str = fetchText("/live-nodes/text?limit=2", "text/plain");
         assertEquals(200, str._1.intValue());
     }
 
@@ -227,6 +225,7 @@ public class ApiControllerTest extends AbstractSchedulerTest {
             .setHostname(ip)
             .setIp(ip)
             .setSeed(false)
+            .setTargetRunState(CassandraFrameworkProtos.CassandraNode.TargetRunState.RUN)
             .setJmxConnect(CassandraFrameworkProtos.JmxConnect.newBuilder()
                 .setIp(ip)
                 .setJmxPort(7199))
@@ -257,6 +256,9 @@ public class ApiControllerTest extends AbstractSchedulerTest {
             if (in == null) {
                 return Tuple2.tuple2(responseCode, (JsonNode) MissingNode.getInstance());
             }
+
+            assertEquals("application/json", conn.getHeaderField("Content-Type"));
+
             try {
                 ObjectMapper om = new ObjectMapper();
                 return Tuple2.tuple2(responseCode, om.reader()
@@ -270,7 +272,7 @@ public class ApiControllerTest extends AbstractSchedulerTest {
         }
     }
 
-    private Tuple2<Integer, String> fetchText(String rel) throws Exception {
+    private Tuple2<Integer, String> fetchText(String rel, String expectedContentType) throws Exception {
         HttpURLConnection conn = (HttpURLConnection) resolve(rel).toURL().openConnection();
         try {
             conn.connect();
@@ -286,6 +288,9 @@ public class ApiControllerTest extends AbstractSchedulerTest {
             if (in == null) {
                 return Tuple2.tuple2(responseCode, "");
             }
+
+            assertEquals(expectedContentType, conn.getHeaderField("Content-Type"));
+
             try {
                 StringBuilder sb = new StringBuilder();
                 int rd;


### PR DESCRIPTION
Adds an API endpoint to produce a list of live nodes for specific tools or client libraries.

This is a prerequisite for stress testing. It provides connect information for `nodetool`, `cassandra-stress`, `cqlsh` plus general-purpose JSON and plain text output.

General invocation:
`http://host:port/live-endpoints/json/2`   retrieves two live nodes via json
`http://host:port/live-endpoints/cqlsh`   retrieves one live nodes as a argument (list) for cqlsh

Available 'applications' are `json`, `text`, `cqlsh`, `stress`, `nodetool`