### PR TITLE
Update to maven-protoc-plugin 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -90,9 +90,7 @@ CASSANDRA_FAILOVER_TIMEOUT_SECONDS=604800
 The Cassandra Mesos Framework is a maven project with modules for the Framework, Scheduler, Executor and Model. Standard maven convention applies. The Framework and Executor are both built as `jar-with-dependencies` in addition to their standalone jar, so that they are easy to run and distribute.
 
 ### Install Maven
-The Cassandra Mesos Framework requires an install of Maven between 3.2.1 and 3.2.4 to build.
-
-_NOTE: Maven 3.2.5 has a binary incompatible change with earlier version of Maven 3.2.x and will cause an exception to be thrown when the protobuf tool chain tries to run._
+The Cassandra Mesos Framework requires an install of Maven 3.x.x.
 
 ## Cassandra memory usage
 

--- a/cassandra-mesos-model/pom.xml
+++ b/cassandra-mesos-model/pom.xml
@@ -78,7 +78,7 @@
                 <configuration>
                     <toolchains>
                         <protobuf>
-                            <version>[2.5,2.6)</version>
+                            <version>2.5.0</version>
                         </protobuf>
                     </toolchains>
                 </configuration>
@@ -86,7 +86,7 @@
             <plugin>
                 <groupId>com.google.protobuf.tools</groupId>
                 <artifactId>maven-protoc-plugin</artifactId>
-                <version>0.3.2</version>
+                <version>0.4.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <checkStaleness>true</checkStaleness>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     </issueManagement>
 
     <prerequisites>
-        <maven>3.0.0</maven>
+        <maven>3.2.0</maven>
     </prerequisites>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,10 @@
         <url>https://github.com/mesosphere/cassandra-mesos/issues</url>
     </issueManagement>
 
+    <prerequisites>
+        <maven>3.0.0</maven>
+    </prerequisites>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <version.java>1.7</version.java>


### PR DESCRIPTION
New version includes fix for breaking changes to maven-toolchains-plugin introduced in maven 3.2.5.