### PR TITLE
Replace node

### DIFF
--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutor.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutor.java
@@ -242,6 +242,11 @@ public final class CassandraExecutor implements Executor {
         if (serverTask != null && serverTask.getTaskId().equals(taskId)) {
             killCassandraDaemon(driver);
         }
+        else if (executorInfo.getExecutorId().getValue().equals(taskId.getValue())) {
+            safeShutdown(driver);
+            driver.sendStatusUpdate(taskStatus(executorInfo.getExecutorId(), taskId, TaskState.TASK_FINISHED, nullSlaveStatusDetails()));
+            driver.stop();
+        }
     }
 
     @Override

--- a/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/MockExecutorDriver.java
+++ b/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/MockExecutorDriver.java
@@ -32,7 +32,7 @@ public class MockExecutorDriver implements ExecutorDriver {
     private List<Protos.TaskStatus> taskStatusList = new ArrayList<>();
     private List<CassandraFrameworkProtos.SlaveStatusDetails> frameworkMessages = new ArrayList<>();
 
-    public MockExecutorDriver(Executor executor) {
+    public MockExecutorDriver(Executor executor, Protos.ExecutorID executorId) {
         this.executor = executor;
 
         slaveInfo = Protos.SlaveInfo.newBuilder()
@@ -47,7 +47,7 @@ public class MockExecutorDriver implements ExecutorDriver {
                 .setUser("me-myself-and-i")
                 .build();
         executorInfo = Protos.ExecutorInfo.newBuilder()
-                .setExecutorId(Protos.ExecutorID.newBuilder().setValue(UUID.randomUUID().toString()))
+                .setExecutorId(executorId)
                 .setCommand(Protos.CommandInfo.getDefaultInstance())
                 .setContainer(Protos.ContainerInfo.newBuilder()
                         .setType(Protos.ContainerInfo.Type.MESOS))

--- a/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
+++ b/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
@@ -147,7 +147,7 @@ public final class Main {
             clock,
             httpServerBaseUri.toString(),
             new ExecutorCounter(state, 0L),
-            new PersistedCassandraClusterState(state),
+            new PersistedCassandraClusterState(state, executorCount),
             new PersistedCassandraClusterHealthCheckHistory(state),
             new PersistedCassandraClusterJobs(state),
             configuration

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -97,6 +97,8 @@ message CassandraClusterState {
     repeated CassandraNode nodes = 1;
     repeated ExecutorMetadata executorMetadata = 2;
     optional int64 lastServerLaunchTimestamp = 3;
+    repeated string replaceNodeIps = 4;
+    required int32 nodesToAcquire = 5;
 }
 
 message CassandraClusterHealthCheckHistory {
@@ -178,6 +180,8 @@ message CassandraNode {
 
     optional int32 cassandraDaemonPid = 12;
 
+    optional string replacementForIp = 13;
+
     enum TargetRunState {
         // If the server task is not active, it is started.
         // Note that general bootstrap-grace-time settings and other checks (e.g. currently other nodes joining) apply.
@@ -188,9 +192,11 @@ message CassandraNode {
         // If the server-task is active, a server-task shutdown is initiated.
         // Note that general bootstrap-grace-time settings and other checks (e.g. currently other nodes joining) apply.
         RESTART = 2;
+        // Terminate all tasks including the executor itself. There's no way back for a terminated node.
+        TERMINATE = 3;
     }
 
-    optional NodeLocation location = 13;
+    optional NodeLocation location = 14;
 }
 message NodeLocation {
     required string datacenter = 1;

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -695,7 +695,7 @@ public final class ApiController {
         return nodeStatusUpdate(cassandraNode);
     }
 
-    @GET
+    @POST
     @Path("/node/terminate/{node}")
     public Response nodeTerminate(@PathParam("node") String node) {
         CassandraFrameworkProtos.CassandraNode cassandraNode = cluster.nodeTerminate(node);
@@ -735,7 +735,7 @@ public final class ApiController {
         return Response.status(status).entity(sw.toString()).type("application/json").build();
     }
 
-    @GET
+    @POST
     @Path("/node/replace/{node}")
     public Response nodeReplace(@PathParam("node") String node) {
         int status = 200;

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -179,9 +179,22 @@ public final class ApiController {
 
             json.writeStartObject();
             CassandraFrameworkProtos.CassandraClusterState clusterState = cluster.getClusterState().get();
+
+            json.writeArrayFieldStart("replaceNodes");
+            for (String ip : clusterState.getReplaceNodeIpsList()) {
+                json.writeString(ip);
+            }
+            json.writeEndArray();
+
+            json.writeNumberField("nodesToAcquire", clusterState.getNodesToAcquire());
+
             json.writeArrayFieldStart("nodes");
             for (CassandraFrameworkProtos.CassandraNode cassandraNode : clusterState.getNodesList()) {
                 json.writeStartObject();
+
+                if (cassandraNode.hasReplacementForIp()) {
+                    json.writeStringField("replacementForIp", cassandraNode.getReplacementForIp());
+                }
 
                 writeTask(json, "serverTask", CassandraFrameworkProtosUtils.getTaskForNode(cassandraNode, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
                 writeTask(json, "metadataTask", CassandraFrameworkProtosUtils.getTaskForNode(cassandraNode, CassandraFrameworkProtos.CassandraNodeTask.TaskType.METADATA));
@@ -682,6 +695,14 @@ public final class ApiController {
         return nodeStatusUpdate(cassandraNode);
     }
 
+    @GET
+    @Path("/node/terminate/{node}")
+    public Response nodeTerminate(@PathParam("node") String node) {
+        CassandraFrameworkProtos.CassandraNode cassandraNode = cluster.nodeTerminate(node);
+
+        return nodeStatusUpdate(cassandraNode);
+    }
+
     private static Response nodeStatusUpdate(CassandraFrameworkProtos.CassandraNode cassandraNode) {
 
         int status = 200;
@@ -703,6 +724,46 @@ public final class ApiController {
                     json.writeStringField("executorId", cassandraNode.getCassandraNodeExecutor().getExecutorId());
                 }
                 json.writeStringField("targetRunState", cassandraNode.getTargetRunState().name());
+            }
+
+            json.writeEndObject();
+            json.close();
+        } catch (Exception e) {
+            LOGGER.error("Failed to build JSON response", e);
+            return Response.serverError().build();
+        }
+        return Response.status(status).entity(sw.toString()).type("application/json").build();
+    }
+
+    @GET
+    @Path("/node/replace/{node}")
+    public Response nodeReplace(@PathParam("node") String node) {
+        int status = 200;
+        StringWriter sw = new StringWriter();
+        try {
+            JsonFactory factory = new JsonFactory();
+            JsonGenerator json = factory.createGenerator(sw);
+            json.setPrettyPrinter(new DefaultPrettyPrinter());
+            json.writeStartObject();
+
+            CassandraFrameworkProtos.CassandraNode cassandraNode = cluster.findNode(node);
+
+            if (cassandraNode == null) {
+                status = 404;
+                json.writeBooleanField("success", false);
+                json.writeStringField("reason", "No such node");
+            } else {
+                json.writeStringField("ipToReplace", cassandraNode.getIp());
+                try {
+                    cluster.replaceNode(node);
+
+                    json.writeBooleanField("success", true);
+                    json.writeStringField("hostname", cassandraNode.getHostname());
+                    json.writeStringField("targetRunState", cassandraNode.getTargetRunState().name());
+                } catch (ReplaceNodePreconditionFailed e) {
+                    json.writeBooleanField("success", false);
+                    json.writeStringField("reason", e.getMessage());
+                }
             }
 
             json.writeEndObject();

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -199,7 +199,7 @@ public final class CassandraCluster {
             .transform(new ContinuingTransform<CassandraNode.Builder>() {
                 @Override
                 public CassandraNode.Builder apply(final CassandraNode.Builder input) {
-                    if (input.hasCassandraNodeExecutor() && input.getCassandraNodeExecutor().getExecutorId().equals(executorId)) {
+                    if (input.hasCassandraNodeExecutor() && executorTaskId(input).equals(executorId)) {
                         return input
                             .clearTasks();
                     }
@@ -218,6 +218,15 @@ public final class CassandraCluster {
                 .filter(cassandraNodeForTaskId(taskId))
                 .filter(cassandraNodeHasExecutor())
                 .transform(executorIdFromCassandraNode())
+        );
+    }
+
+    @NotNull
+    public Optional<CassandraNode> getNodeForTask(@NotNull final String taskId) {
+        return headOption(
+            from(clusterState.nodes())
+                .filter(cassandraNodeForTaskId(taskId))
+                .filter(cassandraNodeHasExecutor())
         );
     }
 
@@ -267,12 +276,9 @@ public final class CassandraCluster {
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug("> recordHealthCheck(executorId : {}, details : {})", executorId, protoToString(details));
         }
-        if (!details.getHealthy()) {
-            final Optional<CassandraNode> nodeOpt = headOption(
-                from(clusterState.nodes())
-                    .filter(cassandraNodeExecutorIdEq(executorId))
-            );
-            if (nodeOpt.isPresent()) {
+        Optional<CassandraNode> nodeOpt = cassandraNodeForExecutorId(executorId);
+        if (nodeOpt.isPresent()) {
+            if (!details.getHealthy()) {
                 LOGGER.info(
                     "health check result unhealthy for node: {}. Message: '{}'",
                     nodeOpt.get().hasCassandraNodeExecutor() ? nodeOpt.get().getCassandraNodeExecutor().getExecutorId() : nodeOpt.get().getHostname(),
@@ -280,6 +286,12 @@ public final class CassandraCluster {
                     );
                 // TODO: This needs to be smarter, right not it assumes that as soon as it's unhealth it's dead
                 //removeTask(nodeOpt.get().getServerTask().getTaskId());
+            } else {
+                // upon the first healthy response clear the replacementForIp field
+                CassandraNodeTask serverTask = CassandraFrameworkProtosUtils.getTaskForNode(nodeOpt.get(), CassandraNodeTask.TaskType.SERVER);
+                if (serverTask != null && nodeOpt.get().hasReplacementForIp()) {
+                    clusterState.nodeReplaced(nodeOpt.get());
+                }
             }
         }
         healthCheckHistory.record(executorId, clock.now().getMillis(), details);
@@ -306,23 +318,31 @@ public final class CassandraCluster {
 
             CassandraNode.Builder node;
             if (!nodeOption.isPresent()) {
+                if (clusterState.get().getNodesToAcquire() <= 0) {
+                    // number of C* cluster nodes already present
+                    return null;
+                }
+
                 NodeCounts nodeCounts = clusterState.nodeCounts();
                 if (nodeCounts.getNodeCount() >= defaultConfigRole.getNumberOfNodes()) {
                     // number of C* cluster nodes already present
                     return null;
                 }
 
+                String replacementForIp = clusterState.nextReplacementIp();
+
                 boolean buildSeedNode = nodeCounts.getSeedCount() < defaultConfigRole.getNumberOfSeeds();
-                CassandraNode newNode = buildCassandraNode(offer, buildSeedNode);
-                clusterState.nodes(append(
-                        clusterState.nodes(),
-                        newNode
-                ));
+                CassandraNode newNode = buildCassandraNode(offer, buildSeedNode, replacementForIp);
+                clusterState.nodeAcquired(newNode);
                 node = CassandraNode.newBuilder(newNode);
             } else
                 node = CassandraNode.newBuilder(nodeOption.get());
 
             if (!node.hasCassandraNodeExecutor()) {
+                if (node.getTargetRunState() == CassandraNode.TargetRunState.TERMINATE) {
+                    // node completely terminated
+                    return null;
+                }
                 final String executorId = getExecutorIdForOffer(offer);
                 final CassandraNodeExecutor executor = getCassandraNodeExecutorSupplier(executorId);
                 node.setCassandraNodeExecutor(executor);
@@ -335,6 +355,10 @@ public final class CassandraCluster {
             CassandraNodeTask metadataTask = CassandraFrameworkProtosUtils.getTaskForNode(node.build(), CassandraNodeTask.TaskType.METADATA);
             CassandraNodeTask serverTask = CassandraFrameworkProtosUtils.getTaskForNode(node.build(), CassandraNodeTask.TaskType.SERVER);
             if (metadataTask == null) {
+                if (node.getTargetRunState() == CassandraNode.TargetRunState.TERMINATE) {
+                    // node completely terminated
+                    return null;
+                }
                 metadataTask = getMetadataTask(executorId, node.getIp());
                 node.addTasks(metadataTask);
                 result.getLaunchTasks().add(metadataTask);
@@ -345,6 +369,12 @@ public final class CassandraCluster {
                         switch (node.getTargetRunState()) {
                             case RUN:
                                 break;
+                            case TERMINATE:
+
+                                LOGGER.info(marker, "Killing executor {}", executorTaskId(node));
+                                result.getKillTasks().add(Protos.TaskID.newBuilder().setValue(executorTaskId(node)).build());
+
+                                return result;
                             case STOP:
                                 LOGGER.debug(marker, "Cannot launch server (targetRunState==STOP)");
                                 return null;
@@ -429,6 +459,7 @@ public final class CassandraCluster {
                                 break;
                             case STOP:
                             case RESTART:
+                            case TERMINATE:
                                 // stop node for STOP and RESTART
 
                                 LOGGER.info(marker, "Killing server task {}", serverTaskId(node));
@@ -456,9 +487,15 @@ public final class CassandraCluster {
         }
     }
 
+
     @NotNull
-    private String serverTaskId(CassandraNode.Builder node) {
-        return node.getCassandraNodeExecutor().getExecutorId() + ".server";
+    private String executorTaskId(@NotNull CassandraNode.Builder node) {
+        return node.getCassandraNodeExecutor().getExecutorId();
+    }
+
+    @NotNull
+    private String serverTaskId(@NotNull CassandraNode.Builder node) {
+        return executorTaskId(node) + ".server";
     }
 
     private boolean canLaunchServerTask() {
@@ -482,16 +519,20 @@ public final class CassandraCluster {
     @NotNull
     public Optional<CassandraNode> cassandraNodeForExecutorId(String executorId) {
         return headOption(
-                from(clusterState.nodes())
-                        .filter(cassandraNodeExecutorIdEq(executorId))
+            from(clusterState.nodes())
+                .filter(cassandraNodeExecutorIdEq(executorId))
         );
     }
 
-    private CassandraNode buildCassandraNode(Protos.Offer offer, boolean seed) {
+    private CassandraNode buildCassandraNode(Protos.Offer offer, boolean seed, String replacementForIp) {
         CassandraNode.Builder builder = CassandraNode.newBuilder()
                 .setHostname(offer.getHostname())
                 .setTargetRunState(CassandraNode.TargetRunState.RUN)
                 .setSeed(seed);
+        if (replacementForIp != null) {
+            builder.setReplacementForIp(replacementForIp);
+        }
+
         try {
             InetAddress ia = InetAddress.getByName(offer.getHostname());
 
@@ -580,12 +621,16 @@ public final class CassandraCluster {
         // 100 MB per physical CPU core.
         CassandraFrameworkProtosUtils.addTaskEnvEntry(taskEnv, false, "HEAP_NEWSIZE", (int) (configRole.getCpuCores() * 100) + "m");
 
+        ArrayList<String> command = newArrayList("apache-cassandra-" + configRole.getCassandraVersion() + "/bin/cassandra", "-f");
+        if (node.hasReplacementForIp()) {
+            command.add("-Dcassandra.replace_address=" + node.getReplacementForIp());
+        }
         final TaskDetails taskDetails = TaskDetails.newBuilder()
             .setTaskType(TaskDetails.TaskType.CASSANDRA_SERVER_RUN)
             .setCassandraServerRunTask(
                 CassandraServerRunTask.newBuilder()
                     // have to start it in foreground in order to be able to detect runtime status in the executor
-                    .addAllCommand(newArrayList("apache-cassandra-" + configRole.getCassandraVersion() + "/bin/cassandra", "-f"))
+                    .addAllCommand(command)
                     .setTaskConfig(taskConfig)
                     .setVersion(configRole.getCassandraVersion())
                     .setTaskEnv(taskEnv)
@@ -706,7 +751,8 @@ public final class CassandraCluster {
 
     public int updateNodeCount(int nodeCount) {
         try {
-            configuration.numberOfNodes(nodeCount);
+            int newNodeCount = configuration.numberOfNodes(nodeCount);
+            clusterState.acquireNewNodes(newNodeCount);
         } catch (IllegalArgumentException e) {
             LOGGER.info("Cannout update number-of-nodes", e);
         }
@@ -883,8 +929,8 @@ public final class CassandraCluster {
 
     public CassandraNode nodeStop(String node) {
         CassandraNode cassandraNode = findNode(node);
-        if (cassandraNode == null) {
-            return null;
+        if (cassandraNode == null || cassandraNode.getTargetRunState() == CassandraNode.TargetRunState.TERMINATE) {
+            return cassandraNode;
         }
 
         cassandraNode = CassandraFrameworkProtos.CassandraNode.newBuilder(cassandraNode)
@@ -897,8 +943,8 @@ public final class CassandraCluster {
 
     public CassandraNode nodeRun(String node) {
         CassandraNode cassandraNode = findNode(node);
-        if (cassandraNode == null) {
-            return null;
+        if (cassandraNode == null || cassandraNode.getTargetRunState() == CassandraNode.TargetRunState.TERMINATE) {
+            return cassandraNode;
         }
 
         cassandraNode = CassandraFrameworkProtos.CassandraNode.newBuilder(cassandraNode)
@@ -911,12 +957,26 @@ public final class CassandraCluster {
 
     public CassandraNode nodeRestart(String node) {
         CassandraNode cassandraNode = findNode(node);
+        if (cassandraNode == null || cassandraNode.getTargetRunState() == CassandraNode.TargetRunState.TERMINATE) {
+            return cassandraNode;
+        }
+
+        cassandraNode = CassandraFrameworkProtos.CassandraNode.newBuilder(cassandraNode)
+            .setTargetRunState(CassandraNode.TargetRunState.RESTART)
+            .build();
+        clusterState.addOrSetNode(cassandraNode);
+
+        return cassandraNode;
+    }
+
+    public CassandraNode nodeTerminate(String node) {
+        CassandraNode cassandraNode = findNode(node);
         if (cassandraNode == null) {
             return null;
         }
 
         cassandraNode = CassandraFrameworkProtos.CassandraNode.newBuilder(cassandraNode)
-            .setTargetRunState(CassandraNode.TargetRunState.RESTART)
+            .setTargetRunState(CassandraNode.TargetRunState.TERMINATE)
             .build();
         clusterState.addOrSetNode(cassandraNode);
 
@@ -966,6 +1026,8 @@ public final class CassandraCluster {
     private boolean isLiveNode(CassandraNode node) {
         if (!node.hasCassandraNodeExecutor())
             return false;
+        if (getTaskForNode(node, CassandraNodeTask.TaskType.SERVER) == null)
+            return false;
         HealthCheckHistoryEntry hc = lastHealthCheck(node.getCassandraNodeExecutor().getExecutorId());
         if (hc == null || !hc.hasDetails())
             return false;
@@ -976,5 +1038,31 @@ public final class CassandraCluster {
         if (!info.hasNativeTransportRunning() || !info.hasRpcServerRunning())
             return false;
         return info.getNativeTransportRunning() && info.getRpcServerRunning();
+    }
+
+    public CassandraNode replaceNode(String node) throws ReplaceNodePreconditionFailed {
+        CassandraNode cassandraNode = findNode(node);
+        if (cassandraNode == null) {
+            throw new ReplaceNodePreconditionFailed("Non-existing node " + node);
+        }
+
+        if (cassandraNode.getSeed()) {
+            throw new ReplaceNodePreconditionFailed("Node " + node + " to replace is a seed node");
+        }
+
+        if (isLiveNode(cassandraNode)) {
+            throw new ReplaceNodePreconditionFailed("Cannot replace live node " + node + " - terminate it first");
+        }
+
+        if (!cassandraNode.getTasksList().isEmpty()) {
+            throw new ReplaceNodePreconditionFailed("Node " + node + " to replace has active tasks");
+        }
+
+        if (clusterState.get().getReplaceNodeIpsList().contains(cassandraNode.getIp())) {
+            throw new ReplaceNodePreconditionFailed("Node " + node + " already in replace-list");
+        }
+
+        clusterState.replaceNode(cassandraNode.getIp());
+        return cassandraNode;
     }
 }

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -548,10 +548,10 @@ public final class CassandraCluster {
 
     @NotNull
     private CassandraNodeTask getServerTask(
-            @NotNull final String executorId,
-            @NotNull final String taskId,
-            @NotNull final ExecutorMetadata metadata,
-            @NotNull final CassandraNode.Builder node) {
+        @NotNull final String executorId,
+        @NotNull final String taskId,
+        @NotNull final ExecutorMetadata metadata,
+        @NotNull final CassandraNode.Builder node) {
         CassandraFrameworkConfiguration config = configuration.get();
         CassandraConfigRole configRole = config.getDefaultConfigRole();
         final TaskConfig.Builder taskConfig = TaskConfig.newBuilder(configRole.getCassandraYamlConfig());

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -1023,7 +1023,7 @@ public final class CassandraCluster {
         return result;
     }
 
-    private boolean isLiveNode(CassandraNode node) {
+    public boolean isLiveNode(CassandraNode node) {
         if (!node.hasCassandraNodeExecutor())
             return false;
         if (getTaskForNode(node, CassandraNodeTask.TaskType.SERVER) == null)
@@ -1052,6 +1052,10 @@ public final class CassandraCluster {
 
         if (isLiveNode(cassandraNode)) {
             throw new ReplaceNodePreconditionFailed("Cannot replace live node " + node + " - terminate it first");
+        }
+
+        if (cassandraNode.getTargetRunState() != CassandraNode.TargetRunState.TERMINATE) {
+            throw new ReplaceNodePreconditionFailed("Cannot replace non-terminated node " + node + " - terminate it first");
         }
 
         if (!cassandraNode.getTasksList().isEmpty()) {

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraScheduler.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraScheduler.java
@@ -18,6 +18,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
+import io.mesosphere.mesos.util.CassandraFrameworkProtosUtils;
 import org.apache.mesos.Protos.*;
 import org.apache.mesos.Scheduler;
 import org.apache.mesos.SchedulerDriver;
@@ -121,7 +122,11 @@ public final class CassandraScheduler implements Scheduler {
             }
             switch (status.getState()) {
                 case TASK_STAGING:
+                    // TODO really interested in stating state?
+                    break;
                 case TASK_STARTING:
+                    // TODO really interested in stating state?
+                    break;
                 case TASK_RUNNING:
                     switch (statusDetails.getStatusDetailsType()) {
                         case NULL_DETAILS:

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraFrameworkConfiguration.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraFrameworkConfiguration.java
@@ -139,14 +139,17 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
         return get().getFrameworkName();
     }
 
-    public void numberOfNodes(int numberOfNodes) {
+    public int numberOfNodes(int numberOfNodes) {
         CassandraFrameworkProtos.CassandraConfigRole configRole = getDefaultConfigRole();
-        if (numberOfNodes <= 0 || configRole.getNumberOfSeeds() > numberOfNodes || numberOfNodes < configRole.getNumberOfNodes())
+        int newNodeCount = numberOfNodes - configRole.getNumberOfNodes();
+        if (numberOfNodes <= 0 || configRole.getNumberOfSeeds() > numberOfNodes || newNodeCount <= 0)
             throw new IllegalArgumentException("Cannot set number of nodes to " + numberOfNodes + ", current #nodes=" + configRole.getNumberOfNodes() + " #seeds=" + configRole.getNumberOfSeeds());
 
         setDefaultConfigRole(CassandraFrameworkProtos.CassandraConfigRole.newBuilder(configRole)
             .setNumberOfNodes(numberOfNodes)
             .build());
+
+        return newNodeCount;
     }
 
     private void setDefaultConfigRole(CassandraFrameworkProtos.CassandraConfigRole configRole) {

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ReplaceNodePreconditionFailed.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ReplaceNodePreconditionFailed.java
@@ -1,0 +1,20 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+public class ReplaceNodePreconditionFailed extends Exception {
+    public ReplaceNodePreconditionFailed(String msg) {
+        super(msg);
+    }
+}

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractSchedulerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractSchedulerTest.java
@@ -32,11 +32,13 @@ public abstract class AbstractSchedulerTest {
 
     CassandraCluster cluster;
 
+    int activeNodes;
     @SuppressWarnings("unchecked")
     final Tuple2<Protos.SlaveID, String>[] slaves = new Tuple2[]{
             Tuple2.tuple2(Protos.SlaveID.newBuilder().setValue(randomID()).build(), "127.1.1.1"),
             Tuple2.tuple2(Protos.SlaveID.newBuilder().setValue(randomID()).build(), "127.2.2.2"),
-            Tuple2.tuple2(Protos.SlaveID.newBuilder().setValue(randomID()).build(), "127.3.3.3")
+            Tuple2.tuple2(Protos.SlaveID.newBuilder().setValue(randomID()).build(), "127.3.3.3"),
+            Tuple2.tuple2(Protos.SlaveID.newBuilder().setValue(randomID()).build(), "127.4.4.4")
     };
 
     protected void cleanState() {
@@ -63,7 +65,7 @@ public abstract class AbstractSchedulerTest {
         cluster = new CassandraCluster(new SystemClock(),
                 "http://127.0.0.1:65535",
                 new ExecutorCounter(state, 0L),
-                new PersistedCassandraClusterState(state),
+                new PersistedCassandraClusterState(state, defaultConfigRole.getNumberOfNodes()),
                 new PersistedCassandraClusterHealthCheckHistory(state),
                 new PersistedCassandraClusterJobs(state),
                 configuration);

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
@@ -229,6 +229,13 @@ public class ApiControllerTest extends AbstractSchedulerTest {
             .setJmxConnect(CassandraFrameworkProtos.JmxConnect.newBuilder()
                 .setIp(ip)
                 .setJmxPort(7199))
+            .addTasks(CassandraFrameworkProtos.CassandraNodeTask.newBuilder()
+                .setExecutorId(executorId)
+                .setTaskId(executorId + ".server")
+                .setTaskType(CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER)
+                .setCpuCores(1)
+                .setMemMb(1)
+                .setDiskMb(1))
             .build());
         cluster.recordHealthCheck(executorId, healthCheckDetailsSuccess("NORMAL", true));
     }


### PR DESCRIPTION
Now that's #45 is merged, here's the follow-up for "replace node".

To replace a node, it must first be terminated (i.e. executor shutdown).