### PR TITLE
Tools using live endpoint API

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -325,3 +325,30 @@ curl -s http://192.168.5.101:18080/live-nodes/ascii/2
 ```
 
 Note that the implementation does a best-effort approach to return random nodes.
+
+## Using Cassandra-on-Mesos with DataStax Java Driver
+
+The artifact `java-driver-extension` provides the `CassandraOnMesos` tool class that 
+configures the DataStax Java Driver with native protocol port and contact points from the information
+available from the Cassandra-on-Mesos framework.
+
+You need to have the base-API-URI provided the framework.
+A typical base-API-URI looks like this: {@code http://192.168.1.2:18080/}
+
+To use the DataStax Java Driver, construct the {@link Cluster} instance as follows:
+
+```java
+import com.datastax.driver.core.Cluster;
+import io.mesosphere.mesos.frameworks.cassandra.javadriver.CassandraOnMesos;
+```
+
+```java
+Cluster.Builder clusterBuilder =
+    CassandraOnMesos.forClusterBuilder(Cluster.builder())
+        .withApiEndpoint(httpServerBaseUri)
+        .withNumberOfContactPoints(2)
+        .build();
+// the Cluster.Builder instance is now configured with two live initial contact points
+clusterBuilder.withClusterName(...);
+Cluster cluster = clusterBuilder.build();
+```

--- a/driver-extensions/README.txt
+++ b/driver-extensions/README.txt
@@ -1,0 +1,2 @@
+Independent parent project that provides support for various drivers and tools to
+ease accessing Cassandra-on-Mesos.

--- a/driver-extensions/java-driver-extension/pom.xml
+++ b/driver-extensions/java-driver-extension/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.mesosphere.mesos.frameworks</groupId>
+        <artifactId>cassandra-support</artifactId>
+        <version>0.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>java-driver-extension</artifactId>
+
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>Apache License Version 2.0</comments>
+        </license>
+    </licenses>
+    <organization>
+        <name>Apache Mesos Cassandra framework</name>
+        <url>http://mesos.apache.org/</url>
+    </organization>
+    <developers>
+        <developer>
+            <name>Ben Whitehead</name>
+            <email>ben.whitehead@mesosphere.io</email>
+        </developer>
+        <developer>
+            <name>Robert Stupp</name>
+            <email>snazy@snazy.de</email>
+        </developer>
+    </developers>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+    <scm>
+        <connection>scm:git:https://github.com/mesosphere/cassandra-mesos.git</connection>
+        <developerConnection>scm:git:https://github.com/mesosphere/cassandra-mesos.git</developerConnection>
+        <url>https://github.com/mesosphere/cassandra-mesos</url>
+    </scm>
+    <issueManagement>
+        <system>Github</system>
+        <url>https://github.com/mesosphere/cassandra-mesos/issues</url>
+    </issueManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.datastax.cassandra</groupId>
+            <artifactId>cassandra-driver-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.glassfish.jersey.containers</groupId>
+            <artifactId>jersey-container-grizzly2-http</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/driver-extensions/java-driver-extension/src/main/java/io/mesosphere/mesos/frameworks/cassandra/javadriver/CassandraOnMesos.java
+++ b/driver-extensions/java-driver-extension/src/main/java/io/mesosphere/mesos/frameworks/cassandra/javadriver/CassandraOnMesos.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra.javadriver;
+
+import com.datastax.driver.core.Cluster;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
+import com.fasterxml.jackson.core.json.JsonReadContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+
+/**
+ * Configures the <a href="https://github.com/datastax/java-driver">DataStax Java Driver</a> with native protocol port and contact points from the information
+ * available from the Cassandra-on-Mesos framework.
+ * <p>
+ *     You need to have the base-API-URI provided the framework.
+ *     A typical base-API-URI looks like this: {@code http://192.168.1.2:18080/}
+ * </p>
+ * <p>
+ *     To use the DataStax Java Driver, construct the {@link Cluster} instance as follows:
+ * </p>
+ *     <pre><code>
+ *         Cluster.Builder clusterBuilder =
+ *             CassandraOnMesos.forClusterBuilder(Cluster.builder())
+ *                 .withApiEndpoint(httpServerBaseUri)
+ *                 .withNumberOfContactPoints(2)
+ *                 .build();
+ *         // the Cluster.Builder instance is now configured with two live initial contact points
+ *         clusterBuilder.withClusterName(...);
+ *         Cluster cluster = clusterBuilder.build();
+ *     </code></pre>
+ *
+ * <p>
+ *     See <a href="https://github.com/datastax/java-driver">DataStax Java Driver</a>.
+ * </p>
+ */
+public final class CassandraOnMesos {
+    private final Cluster.Builder clusterBuilder;
+
+    private URI apiEndpoint;
+    private int numberOfContactPoints = 3;
+
+    private CassandraOnMesos(Cluster.Builder clusterBuilder) {
+        this.clusterBuilder = clusterBuilder;
+    }
+
+    @NotNull
+    public static CassandraOnMesos forClusterBuilder(@NotNull Cluster.Builder clusterBuilder) {
+        if (clusterBuilder == null) {
+            throw new NullPointerException("Must specify clusterBuilder");
+        }
+        return new CassandraOnMesos(clusterBuilder);
+    }
+
+    public URI getApiEndpoint() {
+        return apiEndpoint;
+    }
+
+    /**
+     * Set the base-API-URI provided the Cassandra-on-Mesos framework.
+     * A typical base-API-URI looks like this: {@code http://192.168.1.2:18080/}
+     */
+    @NotNull
+    public CassandraOnMesos withApiEndpoint(@NotNull URI apiEndpoint) {
+        if (apiEndpoint == null) {
+            throw new NullPointerException("Must specify apiEndpoint");
+        }
+        this.apiEndpoint = apiEndpoint;
+        return this;
+    }
+
+    public int getNumberOfContactPoints() {
+        return numberOfContactPoints;
+    }
+
+    /**
+     * Set the number of contact points (live C* nodes) to configure.
+     * Defaults to 3.
+     */
+    @NotNull
+    public CassandraOnMesos withNumberOfContactPoints(int numberOfContactPoints) {
+        this.numberOfContactPoints = numberOfContactPoints;
+        return this;
+    }
+
+    /**
+     * Fetches information about live nodes from Cassandra-on-Mesos framework and updates the
+     * {@link Cluster.Builder} instance with correct native protocol port and contact points.
+     */
+    public Cluster.Builder build() throws IOException {
+        if (apiEndpoint == null) {
+            throw new NullPointerException("Must configure apiEndpoint on CassandraOnMeos");
+        }
+
+        URI uri = apiEndpoint.resolve("/live-nodes?limit=" + numberOfContactPoints);
+        HttpURLConnection connection = (HttpURLConnection) uri.toURL().openConnection();
+        try {
+            connection.connect();
+            if (connection.getResponseCode() != 200) {
+                throw new IOException("Got HTTP/" + connection.getResponseCode() + " for " + uri.toString());
+            }
+
+            try (InputStream inputStram = connection.getInputStream()) {
+                JsonParser parser = new JsonFactory().createParser(inputStram);
+                parser.setCodec(new ObjectMapper());
+                JsonNode jsonDoc = parser.readValueAs(JsonNode.class);
+                clusterBuilder
+                    .withClusterName(jsonDoc.get("clusterName").asText())
+                    .withPort(jsonDoc.get("nativePort").asInt());
+                for (JsonNode liveNodeIp : jsonDoc.get("liveNodes")) {
+                    clusterBuilder.addContactPoint(liveNodeIp.asText());
+                }
+            }
+
+            return clusterBuilder;
+        } finally {
+            connection.disconnect();
+        }
+    }
+}

--- a/driver-extensions/java-driver-extension/src/test/java/io/mesosphere/mesos/frameworks/cassandra/javadriver/CassandraOnMesosTest.java
+++ b/driver-extensions/java-driver-extension/src/test/java/io/mesosphere/mesos/frameworks/cassandra/javadriver/CassandraOnMesosTest.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra.javadriver;
+
+import com.datastax.driver.core.Cluster;
+import org.glassfish.grizzly.http.server.HttpServer;
+import org.glassfish.jersey.grizzly2.httpserver.GrizzlyHttpServerFactory;
+import org.glassfish.jersey.server.ResourceConfig;
+import org.jetbrains.annotations.NotNull;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.*;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class CassandraOnMesosTest {
+    private HttpServer httpServer;
+    private URI httpServerBaseUri;
+
+    @Test
+    public void testBuilder() throws Exception {
+        Cluster.Builder clusterBuilder =
+            CassandraOnMesos.forClusterBuilder(Cluster.builder())
+                .withApiEndpoint(httpServerBaseUri)
+                .withNumberOfContactPoints(2)
+                .build();
+
+        List<InetSocketAddress> contactPoints = clusterBuilder.getContactPoints();
+        assertEquals(2, contactPoints.size());
+        assertNotNull(clusterBuilder.getClusterName());
+        assertTrue(contactPoints.contains(new InetSocketAddress("127.0.0.1", 111)));
+        assertTrue(contactPoints.contains(new InetSocketAddress("127.0.0.2", 111)));
+    }
+
+    @Before
+    public void before() {
+        try {
+            try (ServerSocket sock = new ServerSocket(0)) {
+                httpServerBaseUri = URI.create(String.format("http://%s:%d/", formatInetAddress(InetAddress.getLocalHost()), sock.getLocalPort()));
+            }
+
+            ResourceConfig rc = new ResourceConfig()
+                .register(new TestController());
+            httpServer = GrizzlyHttpServerFactory.createHttpServer(httpServerBaseUri, rc);
+            httpServer.start();
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+    }
+
+    @After
+    public void cleanup() {
+        if (httpServer != null)
+            httpServer.shutdown();
+    }
+
+    @NotNull
+    private static String formatInetAddress(@NotNull final InetAddress inetAddress) {
+        if (inetAddress instanceof Inet4Address) {
+            final Inet4Address address = (Inet4Address) inetAddress;
+            return address.getHostAddress();
+        } else if (inetAddress instanceof Inet6Address) {
+            final Inet6Address address = (Inet6Address) inetAddress;
+            return String.format("[%s]", address.getHostAddress());
+        } else {
+            throw new IllegalArgumentException("InetAddress type: " + inetAddress.getClass().getName() + " is not supported");
+        }
+    }
+}

--- a/driver-extensions/java-driver-extension/src/test/java/io/mesosphere/mesos/frameworks/cassandra/javadriver/TestController.java
+++ b/driver-extensions/java-driver-extension/src/test/java/io/mesosphere/mesos/frameworks/cassandra/javadriver/TestController.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra.javadriver;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+@Path("/")
+public class TestController {
+    @GET
+    @Path("/live-nodes")
+    @Produces("application/json")
+    public Response twoNodes(@QueryParam("limit") @DefaultValue("3") int limit) {
+        return Response.ok("{\n" +
+            "  \"clusterName\" : \"Foo Cluster\",\n" +
+            "  \"nativePort\" : 111,\n" +
+            "  \"rpcPort\" : 222,\n" +
+            "  \"jmxPort\" : 333,\n" +
+            "  \"liveNodes\" : [ \"127.0.0.2\", \"127.0.0.1\" ]\n" +
+            "}\n", "application/json").build();
+    }
+}

--- a/driver-extensions/pom.xml
+++ b/driver-extensions/pom.xml
@@ -1,0 +1,174 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.mesosphere.mesos.frameworks</groupId>
+    <artifactId>cassandra-support</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <licenses>
+        <license>
+            <name>Apache 2</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+            <comments>Apache License Version 2.0</comments>
+        </license>
+    </licenses>
+    <organization>
+        <name>Apache Mesos Cassandra framework</name>
+        <url>http://mesos.apache.org/</url>
+    </organization>
+    <developers>
+        <developer>
+            <name>Ben Whitehead</name>
+            <email>ben.whitehead@mesosphere.io</email>
+        </developer>
+        <developer>
+            <name>Robert Stupp</name>
+            <email>snazy@snazy.de</email>
+        </developer>
+    </developers>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+    <scm>
+        <connection>scm:git:https://github.com/mesosphere/cassandra-mesos.git</connection>
+        <developerConnection>scm:git:https://github.com/mesosphere/cassandra-mesos.git</developerConnection>
+        <url>https://github.com/mesosphere/cassandra-mesos</url>
+    </scm>
+    <issueManagement>
+        <system>Github</system>
+        <url>https://github.com/mesosphere/cassandra-mesos/issues</url>
+    </issueManagement>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <version.java>1.7</version.java>
+
+        <version.assertj-core>1.7.1</version.assertj-core>
+        <version.jetbrains.annotations>13.0</version.jetbrains.annotations>
+        <version.junit>4.12</version.junit>
+        <version.grizzly>2.16</version.grizzly>
+        <version.jackson>2.3.2</version.jackson>
+        <version.datastax-java-driver>2.1.4</version.datastax-java-driver>
+    </properties>
+
+    <modules>
+        <module>java-driver-extension</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-core</artifactId>
+                <version>${version.datastax-java-driver}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.glassfish.jersey.containers</groupId>
+                <artifactId>jersey-container-grizzly2-http</artifactId>
+                <version>${version.grizzly}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${version.jackson}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${version.jackson}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>${version.jetbrains.annotations}</version>
+            </dependency>
+
+            <!-- Test Libraries -->
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>${version.junit}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>${version.assertj-core}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>protoc-plugin</id>
+            <url>http://sergei-ivanov.github.com/maven-protoc-plugin/repo/releases/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <source>${version.java}</source>
+                    <target>${version.java}</target>
+                </configuration>
+            </plugin>
+
+            <!-- required for release to Maven Central -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.9.1</version>
+                <configuration>
+                    <windowtitle>Cassandra-Mesos ${project.artifactId}</windowtitle>
+                    <bottom>&amp;copy; 2014 ${project.organization.name} - licensed under &lt;a
+                        href="http://www.apache.org/licenses/LICENSE-2.0" target="_new"&gt;Apache License, Version 2&lt;/a&gt;
+                        - &lt;a href="http://mesos.apache.org/" target="_new"&gt;Homepage&lt;/a&gt;</bottom>
+                    <show>protected</show>
+                    <failOnError>false</failOnError>
+                    <includeDependencySources>false</includeDependencySources>
+                    <includeTransitiveDependencySources>false</includeTransitiveDependencySources>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>javadoc</id> <!-- this is used for inheritance merges -->
+                        <phase>package</phase> <!-- bind to the packaging phase -->
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -169,6 +169,12 @@
                 </exclusions>
             </dependency>
 
+            <dependency>
+                <groupId>com.datastax.cassandra</groupId>
+                <artifactId>cassandra-driver-core</artifactId>
+                <version>${version.datastax-java-driver}</version>
+            </dependency>
+
             <!-- Libraries that make working in java easier -->
             <dependency>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
JavaDriver extension using Cassandra-on-Mesos framework API endpoint to configure native protocol port and initial contact points.

It's implemented as a project that's independent from cassandra-on-mesos-framework. At the moment it's basically just a demo how it could work. For a more complete set we could add code for more drivers (e.g. python) and more convenient shell scripts instead of `nodetool curl`