### PR TITLE
Add shell tool scripts to invoke cqlsh,nodetool,stress

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -238,33 +238,35 @@ CASSANDRA_FILE_PATH=${PROJECT_DIR}/target/framework-package/cassandra.tar.gz
 
 ## Using Cassandra tools
 
-You can use standard command line tools delivered with Apache Cassandra against clusters running on
-Apache Mesos.
+Support for standard command line tools delivered with Apache Cassandra against clusters running on
+Apache Mesos is provided using the provided shell scripts starting with `com-`. These tools use the
+_live nodes API_ discussed below.
+
+These are:
+
+* `com-cqlsh` to invoke `cqlsh` without bothering about actual endpoints. It connects to any (random)
+  live Cassandra node.
+* `com-nodetool` to invoke `nodetool` without bothering about actual endpoints. It connects to any (random)
+  live Cassandra node.
+* `com-stress` to invoke `cassandra-stress` without bothering about actual endpoints. It connects to any (random)
+  live Cassandra node.
+
+All these tools are configured using environment variables and special command line options. These command
+line options must be specified directly after the command name.
+ 
+Environment variables:
+
+* `CASSANDRA_HOME` path to where your local unpacked Apache Cassandra distribution lives. Defaults to `.`
+* `API_HOST` host name where the Cassandra-on-Mesos scheduler is running. Defaults to `127.0.0.1`
+* `API_PORT` port on which the Cassandra-on-Mesos scheduler is listening. Defaults to `18080`
+
+Command line options:
+* `--limit N` the number of live nodes to use. Has no effect for cqlsh or nodetool.
+
+## Live Cassandra nodes API
 
 This framework provides API endpoints for most tools. All you need is `curl` and the hostname/IP of
 the node running the scheduler of this framework.
-
-An example how to invoke `nodetool`:
-
-```
-cassandra/2.1/bin/nodetool `curl -s http://192.168.5.101:18080/live-nodes/nodetool` status
-Datacenter: datacenter1
-=======================
-Status=Up/Down
-|/ State=Normal/Leaving/Joining/Moving
---  Address    Load       Tokens  Owns (effective)  Host ID                               Rack
-UN  127.0.0.1  41,12 KB   256     100,0%            dc04253f-d878-4d44-acf3-dc014e058b03  rack1
-UN  127.0.0.2  55,51 KB   256     100,0%            685e82e9-fa26-4d12-bee3-13d4f823f5c9  rack1
-```
-
-More examples (note that you have to adjust the path `cassandra/2.1` to where your Apache Cassandra
-distribution lives):
-
-```
-cassandra/2.1/bin/cqlsh `curl -s http://192.168.5.101:18080/live-nodes/cqlsh`
-cassandra/2.1/bin/nodetool `curl -s http://192.168.5.101:18080/live-nodes/nodetool` status
-cassandra/2.1/tools/bin/cassandra-stress read `curl -s http://192.168.5.101:18080/live-nodes/stress`
-```
 
 There are also two endpoints - one returns a simple JSON structure and one just plain ASCII with the native port
 in the first line and node IP addresses on each following line. The number as the last part of the path determines

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -348,7 +348,7 @@ public final class ApiController {
     @Path("/live-nodes/stress")
     @Produces("text/x-cassandra-stress")
     public Response liveEndpointsStress(@QueryParam("limit") @DefaultValue("3") int limit) {
-        return liveEndpoints("stress", 1);
+        return liveEndpoints("stress", limit);
     }
 
     private Response liveEndpoints(String forTool, int limit) {

--- a/driver-extensions/shell-scripts/bin/com-cqlsh
+++ b/driver-extensions/shell-scripts/bin/com-cqlsh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+_BINARY=bin/cqlsh
+_LIVE_NODES_TYPE=cqlsh
+. `dirname $0`/com.in.sh
+#exec `dirname $0`/com_bin bin/cqlsh cqlsh "$@"
+
+exec ${EXEC} ${ARGS} "$@"

--- a/driver-extensions/shell-scripts/bin/com-defaults-in.sh
+++ b/driver-extensions/shell-scripts/bin/com-defaults-in.sh
@@ -1,0 +1,11 @@
+# This file is used by Cassandra-on-Mesos shell tools.
+
+# Specify the host name where the Cassandra-on-Mesos scheduler is running.
+#API_HOST=127.0.0.1
+
+# Specify the port on which the Cassandra-on-Mesos scheduler is listening for API requests.
+#API_PORT=18080
+
+# Define the path where your local Apache Cassandra distribution has been unpacked.
+# Example: CASSANDRA_HOME=/home/user/apache-cassandra-2.1.4
+#CASSANDRA_HOME=

--- a/driver-extensions/shell-scripts/bin/com-nodetool
+++ b/driver-extensions/shell-scripts/bin/com-nodetool
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+_BINARY=bin/nodetool
+_LIVE_NODES_TYPE=nodetool
+. `dirname $0`/com.in.sh
+#exec `dirname $0`/com_bin bin/nodetool nodetool "$@"
+
+exec ${EXEC} ${ARGS} "$@"

--- a/driver-extensions/shell-scripts/bin/com-stress
+++ b/driver-extensions/shell-scripts/bin/com-stress
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+_BINARY=tools/bin/cassandra-stress
+_LIVE_NODES_TYPE=stress
+. `dirname $0`/com.in.sh
+
+# cassandra-stress
+# (node/port options after other command and options)
+case $1 in
+    help)
+        # cassandra-stress doesn't like node/port options for help command :(
+        exec ${EXEC} "$@"
+        ;;
+    *)
+        exec ${EXEC} "$@" ${ARGS}
+        ;;
+esac

--- a/driver-extensions/shell-scripts/bin/com.in.sh
+++ b/driver-extensions/shell-scripts/bin/com.in.sh
@@ -1,0 +1,36 @@
+# rest of arguments are arguments to cqlsh/nodetool/cassandra-stress
+
+. `dirname $0`/com-defaults-in.sh
+
+# Locate Cassandra home directory
+if [ -z ${CASSANDRA_HOME} ] ; then
+    if [ -d apache-cassandra-* ] ; then
+        export CASSANDRA_HOME=apache-cassandra-*
+    fi
+fi
+
+if [ ! -z ${CASSANDRA_HOME} ] ; then
+    EXEC=${CASSANDRA_HOME}/${_BINARY}
+else
+    EXEC=${_BINARY}
+fi
+
+if [ ! -x ${EXEC} ] ; then
+    echo "Could not locate $EXEC" > /dev/stderr
+    exit 1
+fi
+
+_QUERY_PARAMS=""
+if [ "$1" = "--limit" ] ; then
+    shift
+    _QUERY_PARAMS="limit=$1"
+    shift
+fi
+
+API_HOST=${API_HOST:-"127.0.0.1"}
+API_PORT=${API_PORT:-18080}
+API_BASE_URI=${API_BASE_URI:-"http://$API_HOST:$API_PORT/"}
+
+LIVE_NODES_URI="${API_BASE_URI}live-nodes/${_LIVE_NODES_TYPE}?${_QUERY_PARAMS}"
+
+ARGS=`curl -s ${LIVE_NODES_URI}`


### PR DESCRIPTION
Requires that env var `CASSANDRA_HOME` is set to an un-tared apache-cassandra-2.1.x.tar.gz.

Provides:
`com-cqlsh` to invoke `cqlsh` (com means cassandra-on-mesos)
`com-nodetool`
`com-stress`

Example:
`CASSANDRA_HOME=/Users/snazy/devel/cassandra/2.1 driver-extensions/shell-scripts/bin/com-stress help`
`CASSANDRA_HOME=/Users/snazy/devel/cassandra/2.1 driver-extensions/shell-scripts/bin/com-cqlsh`

Works best with PR #55 ;)