### PR TITLE
Qa report bundle

### DIFF
--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutor.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutor.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
+import java.io.File;
 import java.net.UnknownHostException;
 import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -146,7 +147,8 @@ public final class CassandraExecutor implements Executor {
                         driver.sendStatusUpdate(taskStatus(serverTask, TaskState.TASK_RUNNING,
                             SlaveStatusDetails.newBuilder()
                                 .setStatusDetailsType(SlaveStatusDetails.StatusDetailsType.CASSANDRA_SERVER_RUN)
-                                .setCassandraServerRunMetadata(CassandraServerRunMetadata.newBuilder().setPid(process.getPid()))
+                                .setCassandraServerRunMetadata(CassandraServerRunMetadata.newBuilder()
+                                    .setPid(process.getPid()))
                                 .build()));
                     } catch (LaunchNodeException e) {
                         LOGGER.error(taskIdMarker, "Failed to start Cassandra daemon", e);
@@ -385,6 +387,7 @@ public final class CassandraExecutor implements Executor {
         return ExecutorMetadata.newBuilder()
             .setExecutorId(executorMetadata.getExecutorId())
             .setIp(executorMetadata.getIp())
+            .setWorkdir(new File(".").getAbsolutePath())
             .build();
     }
 

--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutor.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutor.java
@@ -387,7 +387,7 @@ public final class CassandraExecutor implements Executor {
         return ExecutorMetadata.newBuilder()
             .setExecutorId(executorMetadata.getExecutorId())
             .setIp(executorMetadata.getIp())
-            .setWorkdir(new File(".").getAbsolutePath())
+            .setWorkdir(System.getProperty("user.dir"))
             .build();
     }
 

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -340,6 +340,7 @@ message SlaveStatusDetails {
 message ExecutorMetadata {
     required string executorId = 1;
     optional string ip = 2;
+    required string workdir = 3;
 }
 
 message CassandraServerRunMetadata {

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -185,17 +185,12 @@ public final class ApiController {
                     continue;
                 }
 
-                CassandraFrameworkProtos.ExecutorMetadata executorMetadata = cluster.metadataForExecutor(cassandraNode.getCassandraNodeExecutor().getExecutorId());
-                if (executorMetadata == null) {
-                    continue;
-                }
-
-                String workdir = executorMetadata.getWorkdir();
                 pw.println("IP: " + cassandraNode.getIp());
                 pw.println("BASE: http://" + cassandraNode.getIp() + ":5051/");
 
-                pw.println("LOG: " + workdir + "/executor.log");
-                pw.println("LOG: " + workdir + "/apache-cassandra-" + cluster.getConfiguration().getDefaultConfigRole().getCassandraVersion() + "/logs/system.log");
+                for (String logFile : cluster.getNodeLogFiles(cassandraNode)) {
+                    pw.println("LOG: " + logFile);
+                }
 
             }
         } catch (Exception e) {
@@ -250,10 +245,11 @@ public final class ApiController {
 
                 json.writeBooleanField("live", cluster.isLiveNode(cassandraNode));
 
-                json.writeObjectFieldStart("logfiles");
-                json.writeStringField("executor", workdir + "/executor.log");
-                json.writeStringField("cassandraSystemLog", workdir + "/apache-cassandra-" + cluster.getConfiguration().getDefaultConfigRole().getCassandraVersion() + "/logs/system.log");
-                json.writeEndObject();
+                json.writeArrayFieldStart("logfiles");
+                for (String logFile : cluster.getNodeLogFiles(cassandraNode)) {
+                    json.writeString(logFile);
+                }
+                json.writeEndArray();
 
                 json.writeEndObject();
 

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -169,9 +169,14 @@ public final class ApiController {
     @GET
     @Path("/qaReportResources/text")
     public Response qaReportResourcesText() {
+        CassandraFrameworkProtos.CassandraFrameworkConfiguration configuration = cluster.getConfiguration().get();
+        int jmxPort = CassandraCluster.getPortMapping(configuration, CassandraCluster.PORT_JMX);
+
         StringWriter sw = new StringWriter();
         try (PrintWriter pw = new PrintWriter(sw)) {
             // TODO don't write to StringWriter - stream to response as the nodes list might get very long
+
+            pw.println("JMX: " + jmxPort);
 
             CassandraFrameworkProtos.CassandraClusterState clusterState = cluster.getClusterState().get();
             for (CassandraFrameworkProtos.CassandraNode cassandraNode : clusterState.getNodesList()) {
@@ -204,6 +209,9 @@ public final class ApiController {
     @GET
     @Path("/qaReportResources")
     public Response qaReportResources() {
+        CassandraFrameworkProtos.CassandraFrameworkConfiguration configuration = cluster.getConfiguration().get();
+        int jmxPort = CassandraCluster.getPortMapping(configuration, CassandraCluster.PORT_JMX);
+
         StringWriter sw = new StringWriter();
         try {
             // TODO don't write to StringWriter - stream to response as the nodes list might get very long
@@ -213,6 +221,9 @@ public final class ApiController {
             json.setPrettyPrinter(new DefaultPrettyPrinter());
 
             json.writeStartObject();
+
+            json.writeNumberField("jmxPort", jmxPort);
+
             CassandraFrameworkProtos.CassandraClusterState clusterState = cluster.getClusterState().get();
             json.writeObjectFieldStart("nodes");
             for (CassandraFrameworkProtos.CassandraNode cassandraNode : clusterState.getNodesList()) {

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -519,9 +519,11 @@ public final class ApiController {
                 case "text":
                     // produce a simple text with the native port in the first line and one line per live node IP
                     sb = new StringBuilder();
-                    sb.append(nativePort).append('\n');
+                    sb.append("NATIVE: ").append(nativePort).append('\n');
+                    sb.append("RPC: ").append(rpcPort).append('\n');
+                    sb.append("JMX: ").append(jmxPort).append('\n');
                     for (CassandraFrameworkProtos.CassandraNode liveNode : liveNodes) {
-                        sb.append(liveNode.getIp()).append('\n');
+                        sb.append("IP: ").append(liveNode.getIp()).append('\n');
                     }
                     return Response.ok(sb.toString()).build();
             }

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -199,10 +199,18 @@ public final class ApiController {
                 writeTask(json, "metadataTask", CassandraFrameworkProtosUtils.getTaskForNode(cassandraNode, CassandraFrameworkProtos.CassandraNodeTask.TaskType.METADATA));
 // TODO                cassandraNode.getDataVolumesList();
 
+
                 if (!cassandraNode.hasCassandraNodeExecutor()) {
                     json.writeNullField("executorId");
+                    json.writeNullField("workdir");
                 } else {
                     json.writeStringField("executorId", cassandraNode.getCassandraNodeExecutor().getExecutorId());
+                    CassandraFrameworkProtos.ExecutorMetadata executorMetadata = cluster.metadataForExecutor(cassandraNode.getCassandraNodeExecutor().getExecutorId());
+                    if (executorMetadata != null) {
+                        json.writeStringField("workdir", executorMetadata.getWorkdir());
+                    } else {
+                        json.writeNullField("workdir");
+                    }
                 }
                 json.writeStringField("ip", cassandraNode.getIp());
                 json.writeStringField("hostname", cassandraNode.getHostname());

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -1083,4 +1083,17 @@ public final class CassandraCluster {
         clusterState.replaceNode(cassandraNode.getIp());
         return cassandraNode;
     }
+
+    public List<String> getNodeLogFiles(CassandraNode cassandraNode) {
+
+        CassandraFrameworkProtos.ExecutorMetadata executorMetadata = metadataForExecutor(cassandraNode.getCassandraNodeExecutor().getExecutorId());
+        if (executorMetadata == null) {
+            return Collections.emptyList();
+        }
+
+        String workdir = executorMetadata.getWorkdir();
+        return newArrayList(
+            workdir + "/executor.log",
+            workdir + "/apache-cassandra-" + getConfiguration().getDefaultConfigRole().getCassandraVersion() + "/logs/system.log");
+    }
 }

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -154,6 +154,14 @@ public final class CassandraCluster {
         return jobsState;
     }
 
+    public ExecutorMetadata metadataForExecutor(@NotNull String executorId) {
+        for (ExecutorMetadata executorMetadata : clusterState.executorMetadata()) {
+            if (executorId.equals(executorMetadata.getExecutorId()))
+                return executorMetadata;
+        }
+        return null;
+    }
+
     public void removeTask(@NotNull final String taskId, Protos.TaskStatus status) {
         List<CassandraNode> nodes = clusterState.nodes();
         List<CassandraNode> newNodes = new ArrayList<>(nodes.size());

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
@@ -111,7 +111,10 @@ public class ApiControllerTest extends AbstractSchedulerTest {
 
         str = fetchText("/live-nodes/text?limit=2", "text/plain");
         assertEquals(200, str._1.intValue());
-        assertEquals("9042\n1.2.3.4\n", str._2);
+        assertEquals("NATIVE: 9042\n" +
+            "RPC: 9160\n" +
+            "JMX: 7199\n" +
+            "IP: 1.2.3.4\n", str._2);
 
         str = fetchText("/live-nodes/cqlsh", "text/x-cassandra-cqlsh");
         assertEquals(200, str._1.intValue());
@@ -127,7 +130,10 @@ public class ApiControllerTest extends AbstractSchedulerTest {
 
         str = fetchText("/live-nodes/text", "text/plain");
         assertEquals(200, str._1.intValue());
-        assertEquals("9042\n1.2.3.4\n", str._2);
+        assertEquals("NATIVE: 9042\n" +
+            "RPC: 9160\n" +
+            "JMX: 7199\n" +
+            "IP: 1.2.3.4\n", str._2);
 
         //
         // mark node as dead
@@ -179,7 +185,10 @@ public class ApiControllerTest extends AbstractSchedulerTest {
 
         str = fetchText("/live-nodes/text?limit=2", "text/plain");
         assertEquals(200, str._1.intValue());
-        assertEquals("9042\n2.2.2.2\n", str._2);
+        assertEquals("NATIVE: 9042\n" +
+            "RPC: 9160\n" +
+            "JMX: 7199\n" +
+            "IP: 2.2.2.2\n", str._2);
 
         // mark 1st node as live
 

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraClusterStateTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraClusterStateTest.java
@@ -206,6 +206,7 @@ public class CassandraClusterStateTest extends AbstractSchedulerTest {
         return CassandraFrameworkProtos.ExecutorMetadata.newBuilder()
                 .setExecutorId(executorID)
                 .setIp(slave._2)
+                .setWorkdir("/foo/bar/baz")
                 .build();
     }
 

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraSchedulerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraSchedulerTest.java
@@ -1087,7 +1087,8 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
                     .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.EXECUTOR_METADATA)
                     .setExecutorMetadata(CassandraFrameworkProtos.ExecutorMetadata.newBuilder()
                         .setExecutorId(executorIdValue(taskInfo))
-                        .setIp("NO_IP!!!"))
+                        .setIp("NO_IP!!!")
+                        .setWorkdir("/foo/bar/baz"))
                     .build().toByteString())
                 .build());
     }

--- a/driver-extensions/shell-scripts/bin/com-qa-report
+++ b/driver-extensions/shell-scripts/bin/com-qa-report
@@ -1,0 +1,40 @@
+#!/bin/sh
+
+_BINARY=bin/cqlsh
+. `dirname $0`/com.api.in.sh
+
+targetDir="qa-report-`date '+%Y-%m-%d-%H-%M-%S'`"
+if [ ! -z $1 ] ; then
+    targetDir="$1"
+fi
+
+echo "Downloading QA report files to ${targetDir}"
+
+curl -s "${API_BASE_URI}qaReportResources/text" | while read ln ; do
+    case $ln in
+        IP:*)
+            currentIp="`echo $ln | cut -d\  -f 2`"
+            echo "Retrieving log files from ${currentIp}"
+            mkdir -p ${targetDir}/${currentIp}
+            ;;
+        BASE:*)
+            currentBaseUri="`echo $ln | cut -d\  -f 2`"
+            ;;
+        LOG:*)
+            log="`echo $ln | cut -d\  -f 2`"
+            file="`basename ${log}`"
+            echo "   retrieving file ${file} ..."
+            curl -s "${currentBaseUri}files/download.json?path=${log}" > ${targetDir}/${currentIp}/${file}
+            curlExitCode=${PIPESTATUS[0]}
+            if [ "0" != "${curlExitCode}" ] ; then
+                echo "Failed to download ${file} from ${currentIp}. Curl exited with code ${curlExitCode}" > /dev/stderr
+            fi
+            ;;
+    esac
+done
+
+curlExitCode=${PIPESTATUS[0]}
+if [ "0" != "${curlExitCode}" ] ; then
+    echo "Could not retrieve list of executors and log files. Curl exited with code ${curlExitCode}" > /dev/stderr
+    exit ${curlExitCode}
+fi

--- a/driver-extensions/shell-scripts/bin/com-qa-report
+++ b/driver-extensions/shell-scripts/bin/com-qa-report
@@ -1,7 +1,13 @@
 #!/bin/sh
+#
+# com-qa-report captures log files and various information from nodetool from all available nodes.
+# Information from scheduler is currently not included.
+# Archived Cassandra log files are also not included.
+#
 
-_BINARY=bin/cqlsh
-. `dirname $0`/com.api.in.sh
+_BINARY=bin/nodetool
+_LIVE_NODES_TYPE=nodetool
+. `dirname $0`/com.in.sh
 
 targetDir="qa-report-`date '+%Y-%m-%d-%H-%M-%S'`"
 if [ ! -z $1 ] ; then
@@ -10,12 +16,30 @@ fi
 
 echo "Downloading QA report files to ${targetDir}"
 
+function nodetoolInvoke() {
+    ${EXEC} -h $1 -p $2 $3 > $4/nodetool-$3.txt 2>&1
+    ec=$?
+    if [ "0" != "${ec}" ] ; then
+        echo "** nodetool $3 against ${currentIp} failed with exit code ${ec}"
+    fi
+}
+
 curl -s "${API_BASE_URI}qaReportResources/text" | while read ln ; do
     case $ln in
+        JMX:*)
+            jmxPort="`echo $ln | cut -d\  -f 2`"
+            ;;
         IP:*)
             currentIp="`echo $ln | cut -d\  -f 2`"
-            echo "Retrieving log files from ${currentIp}"
             mkdir -p ${targetDir}/${currentIp}
+
+            echo "Retrieving nodetool information from ${currentIp}"
+            nodetoolInvoke ${currentIp} ${jmxPort} version "${targetDir}/${currentIp}"
+            nodetoolInvoke ${currentIp} ${jmxPort} info "${targetDir}/${currentIp}"
+            nodetoolInvoke ${currentIp} ${jmxPort} status "${targetDir}/${currentIp}"
+            nodetoolInvoke ${currentIp} ${jmxPort} tpstats "${targetDir}/${currentIp}"
+
+            echo "Retrieving log files from ${currentIp}"
             ;;
         BASE:*)
             currentBaseUri="`echo $ln | cut -d\  -f 2`"


### PR DESCRIPTION
This PR implements a new API endpoint (`qaReportResources`) that can be used to get and pull all necessary information for a complete QA report.

There are two variants of the endpoint: one returning JSON and one returning plain text. The second one is to be used by cluster-loadtest to also include the C* node logfiles.

Will provide some tooling on that endpoint in a future PR - it's basically "raw" for cluster-loadtest.