### PR TITLE
protobuf model and code cleanup

### DIFF
--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutor.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutor.java
@@ -116,7 +116,7 @@ public final class CassandraExecutor implements Executor {
 
             handleProcessNoLongerAlive(driver);
 
-            switch (taskDetails.getTaskType()) {
+            switch (taskDetails.getType()) {
                 case EXECUTOR_METADATA:
                     final ExecutorMetadataTask executorMetadataTask = taskDetails.getExecutorMetadataTask();
                     final ExecutorMetadata slaveMetadata = collectSlaveMetadata(executorMetadataTask);
@@ -270,7 +270,7 @@ public final class CassandraExecutor implements Executor {
 
             handleProcessNoLongerAlive(driver);
 
-            switch (taskDetails.getTaskType()) {
+            switch (taskDetails.getType()) {
                 case HEALTH_CHECK:
                     LOGGER.info("Received healthCheckTask");
                     healthCheck(driver);

--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ProdObjectFactory.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ProdObjectFactory.java
@@ -85,7 +85,7 @@ final class ProdObjectFactory implements ObjectFactory {
             Files.write(taskFile.getData().toByteArray(), file);
         }
 
-        modifyCassandraYaml(taskIdMarker, cassandraNodeTask, serverConfig);
+        modifyCassandraYaml(taskIdMarker, cassandraNodeTask);
         modifyCassandraEnvSh(taskIdMarker, cassandraNodeTask);
         modifyCassandraRackdc(taskIdMarker, cassandraNodeTask, serverConfig);
     }
@@ -104,8 +104,8 @@ final class ProdObjectFactory implements ObjectFactory {
         LOGGER.info(taskIdMarker, "Building cassandra-rackdc.properties");
 
         Properties props = new Properties();
-        props.put("dc", location != null && !location.getDatacenter().isEmpty() ? location.getDatacenter() : "DC1");
-        props.put("rack", location != null && !location.getRack().isEmpty() ? location.getRack() : "RAC1");
+        props.put("dc", location != null && location.hasDatacenter() ? location.getDatacenter() : "DC1");
+        props.put("rack", location != null && !location.hasRack() ? location.getRack() : "RAC1");
         // Add a suffix to a datacenter name. Used by the Ec2Snitch and Ec2MultiRegionSnitch to append a string to the EC2 region name.
         //props.put("dc_suffix", "");
         // Uncomment the following line to make this snitch prefer the internal ip when possible, as the Ec2MultiRegionSnitch does.
@@ -152,7 +152,7 @@ final class ProdObjectFactory implements ObjectFactory {
     }
 
     @SuppressWarnings("unchecked")
-    private static void modifyCassandraYaml(Marker taskIdMarker, CassandraFrameworkProtos.CassandraServerRunTask cassandraNodeTask, CassandraFrameworkProtos.CassandraServerConfig serverConfig) throws IOException {
+    private static void modifyCassandraYaml(Marker taskIdMarker, CassandraFrameworkProtos.CassandraServerRunTask cassandraNodeTask) throws IOException {
         LOGGER.info(taskIdMarker, "Building cassandra.yaml");
 
         File cassandraYaml = new File("apache-cassandra-" + cassandraNodeTask.getVersion() + "/conf/cassandra.yaml");
@@ -164,7 +164,7 @@ final class ProdObjectFactory implements ObjectFactory {
             yamlMap = (Map<String, Object>) yaml.load(br);
         }
         LOGGER.info(taskIdMarker, "Modifying cassandra.yaml");
-        for (CassandraFrameworkProtos.TaskConfig.Entry entry : serverConfig.getTaskConfig().getVariablesList()) {
+        for (CassandraFrameworkProtos.TaskConfig.Entry entry : cassandraNodeTask.getCassandraServerConfig().getCassandraYamlConfig().getVariablesList()) {
             switch (entry.getName()) {
                 case "seeds":
                     List<Map<String, Object>> seedProviderList = (List<Map<String, Object>>) yamlMap.get("seed_provider");

--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ProdObjectFactory.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ProdObjectFactory.java
@@ -99,13 +99,12 @@ final class ProdObjectFactory implements ObjectFactory {
     }
 
     private static void modifyCassandraRackdc(Marker taskIdMarker, CassandraFrameworkProtos.CassandraServerRunTask cassandraNodeTask, CassandraFrameworkProtos.CassandraServerConfig serverConfig) throws IOException {
-        CassandraFrameworkProtos.NodeLocation location = serverConfig.hasLocation() ? serverConfig.getLocation() : null;
 
         LOGGER.info(taskIdMarker, "Building cassandra-rackdc.properties");
 
         Properties props = new Properties();
-        props.put("dc", location != null && location.hasDatacenter() ? location.getDatacenter() : "DC1");
-        props.put("rack", location != null && !location.hasRack() ? location.getRack() : "RAC1");
+        props.put("dc", "DC1");
+        props.put("rack", "RAC1");
         // Add a suffix to a datacenter name. Used by the Ec2Snitch and Ec2MultiRegionSnitch to append a string to the EC2 region name.
         //props.put("dc_suffix", "");
         // Uncomment the following line to make this snitch prefer the internal ip when possible, as the Ec2MultiRegionSnitch does.

--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/jmx/JmxConnect.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/jmx/JmxConnect.java
@@ -49,31 +49,11 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public interface JmxConnect extends Closeable {
 
-    public MemoryMXBean getMemoryProxy();
+    RuntimeMXBean getRuntimeProxy();
 
-    public RuntimeMXBean getRuntimeProxy();
+    StorageServiceMBean getStorageServiceProxy();
 
-    public MessagingServiceMBean getMessagingServiceProxy();
+    EndpointSnitchInfoMBean getEndpointSnitchInfoProxy();
 
-    public StorageProxyMBean getStorageProxy();
-
-    public StorageServiceMBean getStorageServiceProxy();
-
-    public EndpointSnitchInfoMBean getEndpointSnitchInfoProxy();
-
-    public StreamManagerMBean getStreamManagerProxy();
-
-    public CacheServiceMBean getCacheServiceProxy();
-
-    public CompactionManagerMBean getCompactionManagerProxy();
-
-    public FailureDetectorMBean getFailureDetectorProxy();
-
-    public GCInspectorMXBean getGCInspectorProxy();
-
-    public GossiperMBean getGossiperProxy();
-
-    public HintedHandOffManagerMBean getHintedHandOffManagerProxy();
-
-    public List<String> getColumnFamilyNames(String keyspace);
+    List<String> getColumnFamilyNames(String keyspace);
 }

--- a/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/jmx/ProdJmxConnect.java
+++ b/cassandra-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/jmx/ProdJmxConnect.java
@@ -14,18 +14,8 @@
 package io.mesosphere.mesos.frameworks.cassandra.jmx;
 
 import io.mesosphere.mesos.frameworks.cassandra.CassandraFrameworkProtos;
-import org.apache.cassandra.db.HintedHandOffManager;
-import org.apache.cassandra.db.HintedHandOffManagerMBean;
-import org.apache.cassandra.db.compaction.CompactionManager;
-import org.apache.cassandra.db.compaction.CompactionManagerMBean;
-import org.apache.cassandra.gms.FailureDetector;
-import org.apache.cassandra.gms.FailureDetectorMBean;
-import org.apache.cassandra.gms.GossiperMBean;
 import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
-import org.apache.cassandra.net.MessagingService;
-import org.apache.cassandra.net.MessagingServiceMBean;
 import org.apache.cassandra.service.*;
-import org.apache.cassandra.streaming.StreamManagerMBean;
 
 import javax.management.JMX;
 import javax.management.MBeanServerConnection;
@@ -35,7 +25,6 @@ import javax.management.remote.JMXConnectorFactory;
 import javax.management.remote.JMXServiceURL;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.util.*;
 import java.util.concurrent.locks.ReentrantLock;
@@ -55,8 +44,6 @@ public class ProdJmxConnect implements JmxConnect {
 
     private static final String fmtUrl = "service:jmx:rmi:///jndi/rmi://[%s]:%d/jmxrmi";
 
-    private static final String GOSSIPER_MBEAN_NAME = "org.apache.cassandra.net:type=Gossiper";
-
     private final String host;
     private final int port;
     private final String username;
@@ -66,17 +53,7 @@ public class ProdJmxConnect implements JmxConnect {
     private MBeanServerConnection mbeanServerConn;
 
     private StorageServiceMBean ssProxy;
-    private MessagingServiceMBean msProxy;
-    private StreamManagerMBean streamProxy;
-    private CompactionManagerMBean compactionProxy;
-    private FailureDetectorMBean fdProxy;
-    private CacheServiceMBean cacheService;
-    private StorageProxyMBean spProxy;
-    private HintedHandOffManagerMBean hhProxy;
-    private GCInspectorMXBean gcProxy;
-    private GossiperMBean gossProxy;
     private EndpointSnitchInfoMBean snitchProxy;
-    private MemoryMXBean memProxy;
     private RuntimeMXBean runtimeProxy;
 
     private final ReentrantLock lock = new ReentrantLock();
@@ -116,17 +93,7 @@ public class ProdJmxConnect implements JmxConnect {
             jmxc = null;
             mbeanServerConn = null;
             ssProxy = null;
-            msProxy = null;
-            streamProxy = null;
-            compactionProxy = null;
-            fdProxy = null;
-            cacheService = null;
-            spProxy = null;
-            hhProxy = null;
-            gcProxy = null;
-            gossProxy = null;
             snitchProxy = null;
-            memProxy = null;
             runtimeProxy = null;
         }
     }
@@ -175,32 +142,11 @@ public class ProdJmxConnect implements JmxConnect {
         }
     }
 
-    public MemoryMXBean getMemoryProxy() {
-        if (memProxy == null) {
-            memProxy = newPlatformProxy(ManagementFactory.MEMORY_MXBEAN_NAME, MemoryMXBean.class);
-        }
-        return memProxy;
-    }
-
     public RuntimeMXBean getRuntimeProxy() {
         if (runtimeProxy == null) {
             runtimeProxy = newPlatformProxy(ManagementFactory.RUNTIME_MXBEAN_NAME, RuntimeMXBean.class);
         }
         return runtimeProxy;
-    }
-
-    public MessagingServiceMBean getMessagingServiceProxy() {
-        if (msProxy == null) {
-            msProxy = newProxy(MessagingService.MBEAN_NAME, MessagingServiceMBean.class);
-        }
-        return msProxy;
-    }
-
-    public StorageProxyMBean getStorageProxy() {
-        if (spProxy == null) {
-            spProxy = newProxy(StorageProxy.MBEAN_NAME, StorageProxyMBean.class);
-        }
-        return spProxy;
     }
 
     public StorageServiceMBean getStorageServiceProxy() {
@@ -214,54 +160,6 @@ public class ProdJmxConnect implements JmxConnect {
             snitchProxy = newProxy(ENDPOINT_SNITCH_INFO_NAME, EndpointSnitchInfoMBean.class);
         }
         return snitchProxy;
-    }
-
-    public StreamManagerMBean getStreamManagerProxy() {
-        if (streamProxy == null) {
-            streamProxy = newProxy(StreamManagerMBean.OBJECT_NAME, StreamManagerMBean.class);
-        }
-        return streamProxy;
-    }
-
-    public CacheServiceMBean getCacheServiceProxy() {
-        if (cacheService == null) {
-            cacheService = newProxy(CacheService.MBEAN_NAME, CacheServiceMBean.class);
-        }
-        return cacheService;
-    }
-
-    public CompactionManagerMBean getCompactionManagerProxy() {
-        if (compactionProxy == null) {
-            compactionProxy = newProxy(CompactionManager.MBEAN_OBJECT_NAME, CompactionManagerMBean.class);
-        }
-        return compactionProxy;
-    }
-
-    public FailureDetectorMBean getFailureDetectorProxy() {
-        if (fdProxy == null) {
-            fdProxy = newProxy(FailureDetector.MBEAN_NAME, FailureDetectorMBean.class);
-        }
-        return fdProxy;
-    }
-
-    public GCInspectorMXBean getGCInspectorProxy() {
-        if (gcProxy == null)
-            gcProxy = newProxy(GCInspector.MBEAN_NAME, GCInspectorMXBean.class);
-        return gcProxy;
-    }
-
-    public GossiperMBean getGossiperProxy() {
-        if (gossProxy == null) {
-            gossProxy = newProxy(GOSSIPER_MBEAN_NAME, GossiperMBean.class);
-        }
-        return gossProxy;
-    }
-
-    public HintedHandOffManagerMBean getHintedHandOffManagerProxy() {
-        if (hhProxy == null) {
-            hhProxy = newProxy(HintedHandOffManager.MBEAN_NAME, HintedHandOffManagerMBean.class);
-        }
-        return hhProxy;
     }
 
     public List<String> getColumnFamilyNames(String keyspace) {

--- a/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutorTest.java
+++ b/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraExecutorTest.java
@@ -110,7 +110,7 @@ public class CassandraExecutorTest {
                 taskId,
                 Protos.CommandInfo.getDefaultInstance(),
                 CassandraFrameworkProtos.TaskDetails.newBuilder()
-                        .setTaskType(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB)
+                        .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB)
                         .setNodeJobTask(CassandraFrameworkProtos.NodeJobTask.newBuilder()
                                 .setJobType(jobType))
                         .build(),
@@ -130,7 +130,7 @@ public class CassandraExecutorTest {
         assertTrue(executor.getCurrentJob().isFinished());
 
         driver.frameworkMessage(CassandraFrameworkProtos.TaskDetails.newBuilder()
-                .setTaskType(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB_STATUS)
+                .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS)
                 .build());
         List<CassandraFrameworkProtos.SlaveStatusDetails> messages = driver.frameworkMessages();
         assertEquals(1, messages.size());
@@ -155,7 +155,7 @@ public class CassandraExecutorTest {
                 taskId,
                 Protos.CommandInfo.getDefaultInstance(),
                 CassandraFrameworkProtos.TaskDetails.newBuilder()
-                        .setTaskType(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB)
+                        .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB)
                         .setNodeJobTask(CassandraFrameworkProtos.NodeJobTask.newBuilder()
                                 .setJobType(jobType))
                         .build(),
@@ -165,7 +165,7 @@ public class CassandraExecutorTest {
         taskStartingRunning(taskId);
 
         driver.frameworkMessage(CassandraFrameworkProtos.TaskDetails.newBuilder()
-                .setTaskType(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB_STATUS)
+                .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS)
                 .build());
         List<CassandraFrameworkProtos.SlaveStatusDetails> messages = driver.frameworkMessages();
         assertEquals(1, messages.size());
@@ -198,7 +198,7 @@ public class CassandraExecutorTest {
         assertFalse(executor.getCurrentJob().isFinished());
 
         driver.frameworkMessage(CassandraFrameworkProtos.TaskDetails.newBuilder()
-                .setTaskType(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB_STATUS)
+                .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS)
                 .build());
         messages = driver.frameworkMessages();
         assertEquals(1, messages.size());
@@ -214,7 +214,7 @@ public class CassandraExecutorTest {
         assertTrue(objectFactory.storageServiceProxy.listeners.isEmpty());
 
         driver.frameworkMessage(CassandraFrameworkProtos.TaskDetails.newBuilder()
-                .setTaskType(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB_STATUS)
+                .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS)
                 .build());
         messages = driver.frameworkMessages();
         assertEquals(1, messages.size());
@@ -235,7 +235,7 @@ public class CassandraExecutorTest {
             taskIdMetadata,
             Protos.CommandInfo.getDefaultInstance(),
             CassandraFrameworkProtos.TaskDetails.newBuilder()
-                .setTaskType(CassandraFrameworkProtos.TaskDetails.TaskType.EXECUTOR_METADATA)
+                .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.EXECUTOR_METADATA)
                 .setExecutorMetadataTask(CassandraFrameworkProtos.ExecutorMetadataTask.newBuilder()
                     .setExecutorId(driver.executorInfo.getExecutorId().getValue())
                     .setIp("1.2.3.4")
@@ -252,12 +252,12 @@ public class CassandraExecutorTest {
             taskIdServer,
             Protos.CommandInfo.getDefaultInstance(),
             CassandraFrameworkProtos.TaskDetails.newBuilder()
-                .setTaskType(CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN)
+                .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN)
                 .setCassandraServerRunTask(CassandraFrameworkProtos.CassandraServerRunTask.newBuilder()
                     .setVersion("2.1.2")
                     .addCommand("somewhere")
                     .setCassandraServerConfig(CassandraFrameworkProtos.CassandraServerConfig.newBuilder()
-                        .setTaskConfig(CassandraFrameworkProtos.TaskConfig.newBuilder())
+                        .setCassandraYamlConfig(CassandraFrameworkProtos.TaskConfig.newBuilder())
                         .setTaskEnv(CassandraFrameworkProtos.TaskEnv.newBuilder()))
                     .setJmx(CassandraFrameworkProtos.JmxConnect.newBuilder()
                         .setIp("1.2.3.4")
@@ -275,7 +275,7 @@ public class CassandraExecutorTest {
         assertEquals(Protos.TaskState.TASK_RUNNING, taskStatus.get(1).getState());
 
         driver.frameworkMessage(CassandraFrameworkProtos.TaskDetails.newBuilder()
-            .setTaskType(CassandraFrameworkProtos.TaskDetails.TaskType.HEALTH_CHECK)
+            .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.HEALTH_CHECK)
             .build());
 
         taskStatus = driver.taskStatusList();

--- a/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/TestObjectFactory.java
+++ b/cassandra-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/TestObjectFactory.java
@@ -14,30 +14,23 @@
 package io.mesosphere.mesos.frameworks.cassandra;
 
 import io.mesosphere.mesos.frameworks.cassandra.jmx.JmxConnect;
-import org.apache.cassandra.db.HintedHandOffManagerMBean;
 import org.apache.cassandra.db.compaction.CompactionManager;
-import org.apache.cassandra.db.compaction.CompactionManagerMBean;
-import org.apache.cassandra.gms.FailureDetectorMBean;
-import org.apache.cassandra.gms.GossiperMBean;
 import org.apache.cassandra.locator.EndpointSnitchInfoMBean;
-import org.apache.cassandra.net.MessagingServiceMBean;
-import org.apache.cassandra.service.*;
-import org.apache.cassandra.streaming.StreamManagerMBean;
 import org.jetbrains.annotations.NotNull;
+import org.apache.cassandra.service.ActiveRepairService;
+import org.apache.cassandra.service.StorageServiceMBean;
 import org.slf4j.Marker;
 
-import javax.management.*;
+import javax.management.MBeanNotificationInfo;
+import javax.management.Notification;
+import javax.management.NotificationFilter;
+import javax.management.NotificationListener;
 import javax.management.openmbean.TabularData;
-import java.io.IOException;
 import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
 import java.lang.management.RuntimeMXBean;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
 import java.util.*;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
 
 /**
  * This implementation allows to mock Cassandra for executor's use case.
@@ -107,58 +100,8 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public MemoryMXBean getMemoryProxy() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public RuntimeMXBean getRuntimeProxy() {
             return ManagementFactory.getRuntimeMXBean();
-        }
-
-        @Override
-        public MessagingServiceMBean getMessagingServiceProxy() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public StorageProxyMBean getStorageProxy() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public StreamManagerMBean getStreamManagerProxy() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public CacheServiceMBean getCacheServiceProxy() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public CompactionManagerMBean getCompactionManagerProxy() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public FailureDetectorMBean getFailureDetectorProxy() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public GCInspectorMXBean getGCInspectorProxy() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public GossiperMBean getGossiperProxy() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public HintedHandOffManagerMBean getHintedHandOffManagerProxy() {
-            throw new UnsupportedOperationException();
         }
 
         @Override
@@ -221,7 +164,7 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public List<String> getTokens(String endpoint) throws UnknownHostException {
+        public List<String> getTokens(String endpoint) {
             return Arrays.asList("1", "2");
         }
 
@@ -245,7 +188,7 @@ class TestObjectFactory implements ObjectFactory {
         final List<NotificationListener> listeners = new ArrayList<>();
 
         @Override
-        public void removeNotificationListener(NotificationListener listener, NotificationFilter filter, Object handback) throws ListenerNotFoundException {
+        public void removeNotificationListener(NotificationListener listener, NotificationFilter filter, Object handback) {
             listeners.remove(listener);
         }
 
@@ -255,7 +198,7 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public void removeNotificationListener(NotificationListener listener) throws ListenerNotFoundException {
+        public void removeNotificationListener(NotificationListener listener) {
             listeners.remove(listener);
         }
 
@@ -290,7 +233,7 @@ class TestObjectFactory implements ObjectFactory {
         //
 
         @Override
-        public int forceKeyspaceCleanup(String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException {
+        public int forceKeyspaceCleanup(String keyspaceName, String... columnFamilies) {
             return CompactionManager.AllSSTableOpStatus.SUCCESSFUL.statusCode;
         }
 
@@ -352,7 +295,7 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public List<String> describeRingJMX(String keyspace) throws IOException {
+        public List<String> describeRingJMX(String keyspace) {
             throw new UnsupportedOperationException();
         }
 
@@ -397,17 +340,17 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public void takeSnapshot(String tag, String... keyspaceNames) throws IOException {
+        public void takeSnapshot(String tag, String... keyspaceNames) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void takeColumnFamilySnapshot(String keyspaceName, String columnFamilyName, String tag) throws IOException {
+        public void takeColumnFamilySnapshot(String keyspaceName, String columnFamilyName, String tag) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void clearSnapshot(String tag, String... keyspaceNames) throws IOException {
+        public void clearSnapshot(String tag, String... keyspaceNames) {
             throw new UnsupportedOperationException();
         }
 
@@ -422,32 +365,32 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public void forceKeyspaceCompaction(String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException {
+        public void forceKeyspaceCompaction(String keyspaceName, String... columnFamilies) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public int scrub(boolean disableSnapshot, boolean skipCorrupted, String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException {
+        public int scrub(boolean disableSnapshot, boolean skipCorrupted, String keyspaceName, String... columnFamilies) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public int upgradeSSTables(String keyspaceName, boolean excludeCurrentVersion, String... columnFamilies) throws IOException, ExecutionException, InterruptedException {
+        public int upgradeSSTables(String keyspaceName, boolean excludeCurrentVersion, String... columnFamilies) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void forceKeyspaceFlush(String keyspaceName, String... columnFamilies) throws IOException, ExecutionException, InterruptedException {
+        public void forceKeyspaceFlush(String keyspaceName, String... columnFamilies) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public int forceRepairAsync(String keyspace, boolean isSequential, Collection<String> dataCenters, Collection<String> hosts, boolean primaryRange, boolean repairedAt, String... columnFamilies) throws IOException {
+        public int forceRepairAsync(String keyspace, boolean isSequential, Collection<String> dataCenters, Collection<String> hosts, boolean primaryRange, boolean repairedAt, String... columnFamilies) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public int forceRepairRangeAsync(String beginToken, String endToken, String keyspaceName, boolean isSequential, Collection<String> dataCenters, Collection<String> hosts, boolean repairedAt, String... columnFamilies) throws IOException {
+        public int forceRepairRangeAsync(String beginToken, String endToken, String keyspaceName, boolean isSequential, Collection<String> dataCenters, Collection<String> hosts, boolean repairedAt, String... columnFamilies) {
             throw new UnsupportedOperationException();
         }
 
@@ -462,12 +405,12 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public void decommission() throws InterruptedException {
+        public void decommission() {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void move(String newToken) throws IOException {
+        public void move(String newToken) {
             throw new UnsupportedOperationException();
         }
 
@@ -502,12 +445,12 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public void drain() throws IOException, InterruptedException, ExecutionException {
+        public void drain() {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void truncate(String keyspace, String columnFamily) throws TimeoutException, IOException {
+        public void truncate(String keyspace, String columnFamily) {
             throw new UnsupportedOperationException();
         }
 
@@ -522,7 +465,7 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public void updateSnitch(String epSnitchClassName, Boolean dynamic, Integer dynamicUpdateInterval, Integer dynamicResetInterval, Double dynamicBadnessThreshold) throws ClassNotFoundException {
+        public void updateSnitch(String epSnitchClassName, Boolean dynamic, Integer dynamicUpdateInterval, Integer dynamicResetInterval, Double dynamicBadnessThreshold) {
             throw new UnsupportedOperationException();
         }
 
@@ -557,7 +500,7 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public void joinRing() throws IOException {
+        public void joinRing() {
             throw new UnsupportedOperationException();
         }
 
@@ -632,7 +575,7 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public void resetLocalSchema() throws IOException {
+        public void resetLocalSchema() {
             throw new UnsupportedOperationException();
         }
 
@@ -647,17 +590,17 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public void disableAutoCompaction(String ks, String... columnFamilies) throws IOException {
+        public void disableAutoCompaction(String ks, String... columnFamilies) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void enableAutoCompaction(String ks, String... columnFamilies) throws IOException {
+        public void enableAutoCompaction(String ks, String... columnFamilies) {
             throw new UnsupportedOperationException();
         }
 
         @Override
-        public void deliverHints(String host) throws UnknownHostException {
+        public void deliverHints(String host) {
             throw new UnsupportedOperationException();
         }
 
@@ -697,14 +640,14 @@ class TestObjectFactory implements ObjectFactory {
         }
     }
 
-    final class MockEndpointSnitchInfo implements EndpointSnitchInfoMBean {
+    static final class MockEndpointSnitchInfo implements EndpointSnitchInfoMBean {
         @Override
-        public String getRack(String host) throws UnknownHostException {
+        public String getRack(String host) {
             return "rack";
         }
 
         @Override
-        public String getDatacenter(String host) throws UnknownHostException {
+        public String getDatacenter(String host) {
             return "datacenter";
         }
 

--- a/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
+++ b/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
@@ -96,11 +96,11 @@ public final class Main {
         final double    resourceCpuCores        = Double.parseDouble(   Env.option("CASSANDRA_RESOURCE_CPU_CORES").or("2.0"));
         final long      resourceMemoryMegabytes = Long.parseLong(       Env.option("CASSANDRA_RESOURCE_MEM_MB").or("2048"));
         final long      resourceDiskMegabytes   = Long.parseLong(       Env.option("CASSANDRA_RESOURCE_DISK_MB").or("2048"));
+        final long      javaHeapMb              = Long.parseLong(       Env.option("CASSANDRA_RESOURCE_HEAP_MB").or("0"));
         final long      healthCheckIntervalSec  = Long.parseLong(       Env.option("CASSANDRA_HEALTH_CHECK_INTERVAL_SECONDS").or("60"));
         final long      bootstrapGraceTimeSec   = Long.parseLong(       Env.option("CASSANDRA_BOOTSTRAP_GRACE_TIME_SECONDS").or("120"));
         final String    cassandraVersion        =                       "2.1.2"; // TODO Env.option("CASSANDRA_VERSION").or("2.1.2");
-        final String    clusterName             = frameworkName(        Env.option("CASSANDRA_CLUSTER_NAME"));
-        final String    frameworkName           = frameworkName(        Env.option("FRAMEWORK_NAME").or(Env.option("CASSANDRA_CLUSTER_NAME")));
+        final String    frameworkName           = frameworkName(        Env.option("FRAMEWORK_NAME"));
         final String    zkUrl                   =                       Env.option("CASSANDRA_ZK").or("zk://localhost:2181/cassandra-mesos");
         final long      zkTimeoutMs             = Long.parseLong(       Env.option("CASSANDRA_ZK_TIMEOUT_MS").or("10000"));
         final String    mesosMasterZkUrl        =                       Env.option("MESOS_ZK").or("zk://localhost:2181/mesos");
@@ -120,22 +120,19 @@ public final class Main {
             throw new IllegalArgumentException("number of nodes (" + executorCount + ") and/or number of seeds (" + seedCount + ") invalid");
         }
 
-        CassandraFrameworkProtos.CassandraConfigRole.Builder defaultConfigRole = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
-            .setCassandraVersion(cassandraVersion)
-            .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
-                .setCpuCores(resourceCpuCores)
-                .setDiskMb(resourceDiskMegabytes)
-                .setMemMb(resourceMemoryMegabytes))
-            .setNumberOfNodes(executorCount)
-            .setNumberOfSeeds(seedCount)
-            .setMesosRole(mesosRole);
         final PersistedCassandraFrameworkConfiguration configuration = new PersistedCassandraFrameworkConfiguration(
             state,
             frameworkName,
-            clusterName,
-            defaultConfigRole.build(),
             healthCheckIntervalSec,
-            bootstrapGraceTimeSec
+            bootstrapGraceTimeSec,
+            cassandraVersion,
+            resourceCpuCores,
+            resourceDiskMegabytes,
+            resourceMemoryMegabytes,
+            javaHeapMb,
+            executorCount,
+            seedCount,
+            mesosRole
         );
 
 
@@ -159,7 +156,7 @@ public final class Main {
             clock,
             httpServerBaseUri.toString(),
             new ExecutorCounter(state, 0L),
-            new PersistedCassandraClusterState(state, defaultConfigRole.build()),
+            new PersistedCassandraClusterState(state, executorCount, seedCount),
             new PersistedCassandraClusterHealthCheckHistory(state),
             new PersistedCassandraClusterJobs(state),
             configuration

--- a/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
+++ b/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
@@ -113,7 +113,7 @@ public final class Main {
             matcher.group(1),
             zkTimeoutMs,
             TimeUnit.MILLISECONDS,
-            matcher.group(2) + '/' + frameworkName
+            matcher.group(2)
         );
 
         if (seedCount > executorCount || seedCount <= 0 || executorCount <= 0) {

--- a/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
+++ b/cassandra-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/Main.java
@@ -106,8 +106,6 @@ public final class Main {
         final String    mesosMasterZkUrl        =                       Env.option("MESOS_ZK").or("zk://localhost:2181/mesos");
         final long      failoverTimeout         = Long.parseLong(       Env.option("CASSANDRA_FAILOVER_TIMEOUT_SECONDS").or(String.valueOf(Period.days(7).toStandardSeconds().getSeconds())));
         final String    mesosRole               =                       Env.option("CASSANDRA_FRAMEWORK_MESOS_ROLE").or("*");
-        final String    datacenter              =                       Env.option("CASSANDRA_DATACENTER").orNull();
-        final String    rack                    =                       Env.option("CASSANDRA_RACK").orNull();
 
         final Matcher matcher = validateZkUrl(zkUrl);
 
@@ -131,16 +129,6 @@ public final class Main {
             .setNumberOfNodes(executorCount)
             .setNumberOfSeeds(seedCount)
             .setMesosRole(mesosRole);
-        if (datacenter != null || rack != null) {
-            CassandraFrameworkProtos.NodeLocation.Builder locationBuilder = CassandraFrameworkProtos.NodeLocation.newBuilder();
-            if (datacenter != null) {
-                locationBuilder.setDatacenter(datacenter);
-            }
-            if (rack != null) {
-                locationBuilder.setRack(rack);
-            }
-            defaultConfigRole.setNodeLocation(locationBuilder);
-        }
         final PersistedCassandraFrameworkConfiguration configuration = new PersistedCassandraFrameworkConfiguration(
             state,
             frameworkName,

--- a/cassandra-mesos-model/src/main/java/io/mesosphere/mesos/util/CassandraFrameworkProtosUtils.java
+++ b/cassandra-mesos-model/src/main/java/io/mesosphere/mesos/util/CassandraFrameworkProtosUtils.java
@@ -31,11 +31,6 @@ public final class CassandraFrameworkProtosUtils {
     private CassandraFrameworkProtosUtils() {}
 
     @NotNull
-    public static Function<ExecutorMetadata, String> executorMetadataToIp() {
-        return SlaveMetadataToIp.INSTANCE;
-    }
-
-    @NotNull
     public static Function<CassandraNode, String> cassandraNodeToIp() {
         return CassandraNodeToIp.INSTANCE;
     }
@@ -48,16 +43,6 @@ public final class CassandraFrameworkProtosUtils {
     @NotNull
     public static Function<CassandraNode.Builder, CassandraNode> cassandraNodeBuilderToCassandraNode() {
         return CassandraNodeBuilderToCassandraNode.INSTANCE;
-    }
-
-    @NotNull
-    public static Function<CassandraFrameworkProtos.ExecutorMetadata, CassandraFrameworkProtos.ExecutorMetadata.Builder> executorMetadataToBuilder() {
-        return ExecutorMetadataToBuilder.INSTANCE;
-    }
-
-    @NotNull
-    public static Function<ExecutorMetadata.Builder, ExecutorMetadata> executorMetadataBuilderToExecutorMetadata() {
-        return ExecutorMetadataBuilderToExecutorMetadata.INSTANCE;
     }
 
     @NotNull
@@ -101,18 +86,13 @@ public final class CassandraFrameworkProtosUtils {
     }
 
     @NotNull
-    public static Function<HealthCheckHistoryEntry, String> healthCheckHistoryEntryToExecutorId() {
-        return HealthCheckHistoryEntryToExecutorId.INSTANCE;
-    }
-
-    @NotNull
     public static Function<HealthCheckHistoryEntry, Long> healthCheckHistoryEntryToTimestamp() {
         return HealthCheckHistoryEntryToTimestamp.INSTANCE;
     }
 
     @NotNull
-    public static URI resourceUri(@NotNull final String urlForResource, final boolean extract) {
-        return URI.newBuilder().setValue(urlForResource).setExtract(extract).build();
+    public static FileDownload resourceFileDownload(@NotNull final String urlForResource, final boolean extract) {
+        return FileDownload.newBuilder().setDownloadUrl(urlForResource).setExtract(extract).build();
     }
 
     public static TaskConfig.Entry configValue(@NotNull final String name, @NotNull final Integer value) {
@@ -165,9 +145,9 @@ public final class CassandraFrameworkProtosUtils {
         return null;
     }
 
-    public static CassandraNodeTask getTaskForNode(@NotNull CassandraNode cassandraNode, @NotNull CassandraNodeTask.TaskType taskType) {
+    public static CassandraNodeTask getTaskForNode(@NotNull CassandraNode cassandraNode, @NotNull CassandraNodeTask.NodeTaskType taskType) {
         for (CassandraNodeTask cassandraNodeTask : cassandraNode.getTasksList()) {
-            if (cassandraNodeTask.getTaskType() == taskType)
+            if (cassandraNodeTask.getType() == taskType)
                 return cassandraNodeTask;
         }
         return null;
@@ -183,15 +163,6 @@ public final class CassandraFrameworkProtosUtils {
             }
         }
         return builder;
-    }
-
-    private static final class SlaveMetadataToIp implements Function<ExecutorMetadata, String> {
-        private static final SlaveMetadataToIp INSTANCE = new SlaveMetadataToIp();
-
-        @Override
-        public String apply(@NotNull final ExecutorMetadata input) {
-            return input.getIp();
-        }
     }
 
     private static final class CassandraNodeToIp implements Function<CassandraNode, String> {
@@ -217,24 +188,6 @@ public final class CassandraFrameworkProtosUtils {
 
         @Override
         public CassandraNode apply(@NotNull final CassandraNode.Builder input) {
-            return input.build();
-        }
-    }
-
-    private static final class ExecutorMetadataToBuilder implements Function<CassandraFrameworkProtos.ExecutorMetadata, CassandraFrameworkProtos.ExecutorMetadata.Builder> {
-        private static final ExecutorMetadataToBuilder INSTANCE = new ExecutorMetadataToBuilder();
-
-        @Override
-        public ExecutorMetadata.Builder apply(@NotNull final ExecutorMetadata input) {
-            return ExecutorMetadata.newBuilder(input);
-        }
-    }
-
-    private static final class ExecutorMetadataBuilderToExecutorMetadata implements Function<ExecutorMetadata.Builder, ExecutorMetadata> {
-        private static final ExecutorMetadataBuilderToExecutorMetadata INSTANCE = new ExecutorMetadataBuilderToExecutorMetadata();
-
-        @Override
-        public ExecutorMetadata apply(@NotNull final ExecutorMetadata.Builder input) {
             return input.build();
         }
     }
@@ -343,15 +296,6 @@ public final class CassandraFrameworkProtosUtils {
         }
     }
 
-    private static final class HealthCheckHistoryEntryToExecutorId implements Function<HealthCheckHistoryEntry, String> {
-        private static final HealthCheckHistoryEntryToExecutorId INSTANCE = new HealthCheckHistoryEntryToExecutorId();
-
-        @Override
-        public String apply(@NotNull final HealthCheckHistoryEntry input) {
-            return input.getExecutorId();
-        }
-    }
-
     private static final class HealthCheckHistoryEntryToTimestamp implements Function<HealthCheckHistoryEntry, Long> {
         private static final HealthCheckHistoryEntryToTimestamp INSTANCE = new HealthCheckHistoryEntryToTimestamp();
 
@@ -360,20 +304,4 @@ public final class CassandraFrameworkProtosUtils {
             return input.getTimestampEnd();
         }
     }
-
-    private static final class CassandraNodeToExecutor implements Function<CassandraNode, CassandraNodeExecutor> {
-        private static final CassandraNodeToExecutor INSTANCE = new CassandraNodeToExecutor();
-
-        @Override
-        public CassandraNodeExecutor apply(@NotNull final CassandraNode input) {
-            return input.getCassandraNodeExecutor();
-        }
-    }
-
-    @NotNull
-    public static Function<CassandraNode, CassandraNodeExecutor> cassandraNodeToExecutor() {
-        return CassandraNodeToExecutor.INSTANCE;
-    }
-
-
 }

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -15,44 +15,95 @@ package io.mesosphere.mesos.frameworks.cassandra;
 
 option java_outer_classname = "CassandraFrameworkProtos";
 
+/**
+ * Base configuration object.
+ * This is a top-level object in the state hierarchy.
+ */
 message CassandraFrameworkConfiguration {
+    /**
+     * ID of the framework. Assigned by Mesos when the scheduler is registered.
+     */
     optional string frameworkId = 1;
-    optional string frameworkName = 2;
-    optional int64 healthCheckIntervalSeconds = 3;
-    optional int64 bootstrapGraceTimeSeconds = 4;
-    repeated PortMapping portMapping = 5;
-    optional string snitch = 6;
+    /**
+     * Name of the framework - must be unique for each framework instance.
+     * This is different from cluster since if you have setup multiple Cassandra-on-Mesos
+     * frameworks for each logical data center (with different frameworkName and frameworkId) you
+     * still have the same Cassandra cluster name.
+     */
+    required string frameworkName = 2;
+    /**
+     * Name of the Cassandra cluster.
+     * This is different from frameworkName since if you have setup multiple Cassandra-on-Mesos
+     * frameworks for each logical data center (with different frameworkName and frameworkId) you
+     * still have the same Cassandra cluster name.
+     */
+    required string clusterName = 3;
+    /**
+     * Minimum interval in seconds to ask each executor for a health check response of the Cassandra
+     * server task (= Cassandra process).
+     */
+    required int64 healthCheckIntervalSeconds = 4;
+    /**
+     * Minimum interval in seconds between two starts of a Cassandra server task (= Cassandra process).
+     */
+    required int64 bootstrapGraceTimeSeconds = 5;
+    /**
+     * Globally shared mapping of ports required by Cassandra.
+     * Currently there are port mappings for these kinds of ports and respective default values:
+     * storage_port=7000, ssl_storage_port=7001, native_transport_port=9042, rpc_port=9160, jmx_port=7199
+     */
+    repeated PortMapping portMapping = 6;
+    /**
+     * The class name of the snitch used. Defaults to GossipingPropertyFileSnitch.
+     */
+    optional string snitch = 7;
 
-    // default configuration
-    required CassandraConfigRole defaultConfigRole = 7;
+    /**
+     * Default configuration role.
+     */
+    required CassandraConfigRole defaultConfigRole = 8;
 }
 
-// CassandraConfigRole is currently only used once. But different nodes may require different sizings -
-// e.g. when replacing old metal with new metal. Different DCs may also have different sizings.
-// Individual nodes just reference a "config role".
+/**
+ * CassandraConfigRole is currently only used once. But different nodes may require different sizings -
+ * e.g. when replacing old metal with new metal. Different DCs may also have different sizings.
+ * Individual nodes just reference a "config role".
+ */
 message CassandraConfigRole {
-    // arbitrary name of this configuration - usually "default" but could be something like "16core-128g-4x500gSSD"
+    /**
+     * Arbitrary name of this configuration - usually "default" but could be something like "16core-128g-4x500gSSD".
+     */
     optional string name = 1;
 
+    /**
+     * Cassandra version string. Example: 2.1.4
+     */
     optional string cassandraVersion = 2;
+    /**
+     * Initial target number of Cassandra nodes.
+     */
     optional int32 numberOfNodes = 3;
-    optional double cpuCores = 4;
-    optional int64 diskMb = 6;
-    optional int32 numberOfSeeds = 7;
+    /**
+     * Initial target number of seed nodes.
+     */
+    optional int32 numberOfSeeds = 4;
 
-
-    // total memory required (must be greater than memJavaHeapMb + memAssumeOffHeapMb)
-    optional int64 memMb = 5;
+    /**
+     * The resource to provision.
+     * Total memory must be greater or equal to memJavaHeapMb + memAssumeOffHeapMb.
+     * The field ports is not used in this context.
+     */
+    required TaskResources resources = 5;
 
     // Cassandra memory usage can be categorized into
     // 1. Java heap (MAX_HEAP_SIZE) - including new-gen (HEAP_NEWSIZE)
     //    Amount of Java heap in MB.
     //    (defaults to 50% of memMb, max 16384, if not present)
-    optional int64 memJavaHeapMb = 8;
+    optional int64 memJavaHeapMb = 6;
     // 2. Off-Heap
     //    Amount of Off heap in MB.
     //    (defaults to memMb - memJavaHeapMb, if not present)
-    optional int64 memAssumeOffHeapMb = 9;
+    optional int64 memAssumeOffHeapMb = 7;
     // 3. OS (add as much as possible for OS block cache)
     //    This is just the difference between memMb and memJavaHeapMb + memAssumeOffHeapMb
 
@@ -83,36 +134,94 @@ message CassandraConfigRole {
 
     // additional configuration
     // process environment
-    optional TaskEnv taskEnv = 10;
+    optional TaskEnv taskEnv = 8;
     // cassandra.yaml configuration
-    optional TaskConfig cassandraYamlConfig = 11;
+    optional TaskConfig cassandraYamlConfig = 9;
     // mesos role to be used to receive resource offers
-    optional string mesosRole = 12;
+    optional string mesosRole = 10;
+
+    /**
+     * The default location for nodes.
+     */
+    optional NodeLocation nodeLocation = 11;
 }
 
+/**
+ * One port mapping consisting of a port name and value.
+ */
 message PortMapping {
     required string name = 1;
     required int32 port = 2;
 }
 
+/**
+ * Current status of the cluster.
+ * This is a top-level object in the state hierarchy.
+ */
 message CassandraClusterState {
+    /**
+     * List of all known nodes.
+     */
     repeated CassandraNode nodes = 1;
+    /**
+     * List of all known executors.
+     */
     repeated ExecutorMetadata executorMetadata = 2;
+    /**
+     * Timestamp when the last Cassandra server run task has been submitted.
+     */
     optional int64 lastServerLaunchTimestamp = 3;
+    /**
+     * List of IP addresses of nodes that need to be replaced.
+     */
     repeated string replaceNodeIps = 4;
+    /**
+     * Number of new nodes that have to be acquired.
+     * If replaceNodeIps is not empty, new nodes will start with the -Dcassandra.replace_address=<IP>
+     * option passed to the Cassandra process.
+     */
     required int32 nodesToAcquire = 5;
     required int32 seedsToAcquire = 6;
 }
 
+/**
+ * Contains a history of the last health-checks that were received from all nodes.
+ * The implementation should not add a new entry when it is similar to the previous one.
+ * Instead it should update the timespan in the previous one.
+ * This is a top-level object in the state hierarchy.
+ */
 message CassandraClusterHealthCheckHistory {
+    /**
+     * Configuration option that determines how many entries should be recorded per node.
+     */
     required int32 maxEntriesPerNode = 1;
+    /**
+     * Health check history entries.
+     */
     repeated HealthCheckHistoryEntry entries = 2;
 }
 
+/**
+ * Health check history entry as part of CassandraClusterHealthCheckHistory message.
+ */
 message HealthCheckHistoryEntry {
+    /**
+     * Executor ID from which this entry has been received.
+     */
     required string executorId = 1;
+    /**
+     * First occurence of this entry.
+     * This field differs from timestampEnd when multiple, similar HealthCheckDetails have been received.
+     */
     required int64 timestampStart = 2;
+    /**
+     * Last occurence of this entry.
+     * This field differs from timestampStart when multiple, similar HealthCheckDetails have been received.
+     */
     required int64 timestampEnd = 3;
+    /**
+     * Health check details for this entry.
+     */
     required HealthCheckDetails details = 4;
 }
 
@@ -121,69 +230,176 @@ enum ClusterJobType {
     REPAIR = 2;
     RESTART = 3;
 }
-message CassandraClusterJobs {
-    repeated ScheduledJob jobs = 1;
 
-    optional ClusterJobStatus currentClusterJob = 3;
-    repeated ClusterJobStatus lastClusterJobs = 4;
+/**
+ * State object that contains the current cluster-wide job and the last job status (one per job type).
+ * This is a top-level object in the state hierarchy.
+ */
+message CassandraClusterJobs {
+    /**
+     * The currently executing cluster-wide job.
+     */
+    optional ClusterJobStatus currentClusterJob = 1;
+    /**
+     * List with the last job status per job-type.
+     */
+    repeated ClusterJobStatus lastClusterJobs = 2;
 }
-message ScheduledJob {
-    required ClusterJobType jobType = 1;
-    required int64 scheduledTime = 2;
-    optional RepairScheduledJob repairTask = 3;
-    optional CleanupScheduledJob cleanupTask = 4;
-}
-message CleanupScheduledJob {
-}
-message RepairScheduledJob {
-}
+/**
+ * Status information on a cluster-wide job.
+ */
 message ClusterJobStatus {
+    /**
+     * Type of the cluster-wide job.
+     */
     required ClusterJobType jobType = 1;
+    /**
+     * Timestamp when the cluster-wide job has been started.
+     */
     required int64 startedTimestamp = 2;
+    /**
+     * Timestamp when the cluster-wide job has finished.
+     */
     optional int64 finishedTimestamp = 3;
+    /**
+     * List containing the executor IDs of the nodes that still have to execute the job.
+     */
     repeated string remainingNodes = 4;
+    /**
+     * List with the per-node status of the nodes that finished the job.
+     */
     repeated NodeJobStatus completedNodes = 5;
+    /**
+     * Flag whether the cluster-job should be or has been aborted.
+     */
     optional bool aborted = 6;
+    /**
+     * Job status of the node currently executing.
+     */
     optional NodeJobStatus currentNode = 7;
 }
+/**
+ * Per-node status of a cluster-wide job in ClusterJobStatus.
+ */
 message NodeJobStatus {
+    /**
+     * Executor ID of the node.
+     */
     required string executorId = 1;
+    /**
+     * Task ID of the node-job.
+     */
     required string taskId = 2;
+    /**
+     * Type of the job.
+     */
     required ClusterJobType jobType = 3;
+    /**
+     * Timestamp when the job has been started on the node.
+     */
     optional int64 startedTimestamp = 4;
+    /**
+     * Timestamp when the job has finished on the node.
+     */
     optional int64 finishedTimestamp = 5;
+    /**
+     * Flag whether the job is still running on the node.
+     */
     optional bool running = 6;
+    /**
+     * Flag whether the job failed on the node.
+     */
     optional bool failed = 7;
+    /**
+     * Optional failure message, if failed field is true.
+     */
     optional string failureMessage = 8;
 
+    /**
+     * List of per-keyspace status information.
+     */
     repeated ClusterJobKeyspaceStatus processedKeyspaces = 9;
+    /**
+     * List of remaining keyspaces to process.
+     */
     repeated string remainingKeyspaces = 10;
 }
+/**
+ * Per-keyspace status in NodeJobStatus.
+ */
 message ClusterJobKeyspaceStatus {
+    /**
+     * Name of the keyspace.
+     */
     required string keyspace = 1;
+    /**
+     * Status (depends on job type).
+     */
     required string status = 2;
+    /**
+     * Duration in milliseconds.
+     */
     required int64 duration = 3;
 }
 
+/**
+ * Describes a node.
+ */
 message CassandraNode {
+    /**
+     * Hostname as provided in the Mesos Offer message.
+     */
     required string hostname = 1;
+    /**
+     * IP resolved by the scheduler from hostname as provided in the Mesos Offer message.
+     */
     required string ip = 2;
+    /**
+     * Information how to access JMX on that node.
+     */
     required JmxConnect jmxConnect = 3;
 
+    /**
+     * List of data volumes for the node.
+     * Each DataVolume correspons to a Cassandra JBOD data directory.
+     */
     repeated DataVolume dataVolumes = 4;
+    /**
+     * Information about the executor for this node.
+     */
     optional CassandraNodeExecutor cassandraNodeExecutor = 5;
 
+    /**
+     * Tasks submitted to this node.
+     */
     repeated CassandraNodeTask tasks = 6;
 
+    /**
+     * Flag whether the node is a seed node.
+     */
     required bool seed = 8;
+    /**
+     * Timestamp when the last repair ran on this node.
+     */
     optional int64 lastRepairTimestamp = 9;
+    /**
+     * Timestamp when the last cleanup ran on this node.
+     */
     optional int64 lastCleanupTimestamp = 10;
 
-    // Indicates whether a node should run or not.
+    /**
+     * Indicates whether a node should run or not.
+     */
     required TargetRunState targetRunState = 11;
 
+    /**
+     * The process ID of the Cassandra process.
+     */
     optional int32 cassandraDaemonPid = 12;
 
+    /**
+     * IP of the node that this node is about to replace.
+     */
     optional string replacementForIp = 13;
 
     enum TargetRunState {
@@ -200,85 +416,240 @@ message CassandraNode {
         TERMINATE = 3;
     }
 
+    /**
+     * Location (data center + rack) of this node.
+     */
     optional NodeLocation location = 14;
 
     // The configuration files of this node need to be updated, but the Cassandra server process does not
     // need to be restarted.
     optional bool needsConfigUpdate = 15;
 }
+/**
+ * Contains data center + rack information.
+ */
 message NodeLocation {
-    required string datacenter = 1;
-    required string rack = 2;
+    /**
+     * Name of the data center.
+     */
+    optional string datacenter = 1;
+    /**
+     * Name of the rack.
+     */
+    optional string rack = 2;
 }
+/**
+ * Describes a data volume for a node.
+ */
 message DataVolume {
+    /**
+     * Data volume (= Cassandra data directory) path.
+     */
     required string path = 1;
+    /**
+     * Size in MB.
+     */
     required int64 sizeMb = 2;
 }
+/**
+ * Holder for resources to be provisioned for a task.
+ */
+message TaskResources {
+    /**
+     * Number of CPU cores to provision.
+     */
+    optional double cpuCores = 1;
+    /**
+     * Amount of disk space to provision.
+     */
+    optional int64 diskMb = 2;
+    /**
+     * Amount of memory to provision.
+     */
+    required int64 memMb = 3;
+    /**
+     * Port ranges to provision.
+     */
+    repeated int64 ports = 4;
+}
+/**
+ * Describes the executor process on a node.
+ */
 message CassandraNodeExecutor {
+    /**
+     * ID of the executor.
+     */
     required string executorId = 1;
+    /**
+     * Source (= framework name).
+     */
     required string source = 2;
-    required double cpuCores = 3;
-    required int64 memMb = 4;
-    required int64 diskMb = 5;
-    repeated int64 ports = 6;
+    /**
+     * Resources to be provisioned for the executor process.
+     */
+    required TaskResources resources = 3;
 
+    /**
+     * Executor process command and arguments.
+     */
     repeated string command = 7;
 
+    /**
+     * Executor process environment.
+     */
     optional TaskEnv taskEnv = 8;
 
-    repeated URI resource = 9;
+    /**
+     * Required resources that must be downloaded.
+     */
+    repeated FileDownload download = 5;
 }
-message URI {
-    required string value = 1;
+
+/**
+ * File to be downloaded.
+ */
+message FileDownload {
+    /**
+     * URL to download the file from.
+     */
+    required string downloadUrl = 1;
+    /**
+     * Flag whether the file is executable.
+     */
     optional bool executable = 2;
+    /**
+     * Flag whether to extract the file (for example .tar.gz bundles)
+     */
     optional bool extract = 3;
 }
 
+/**
+ * Describes a task for a node.
+ */
 message CassandraNodeTask {
-    required TaskType taskType = 1;
+    /**
+     * Type of task.
+     */
+    required NodeTaskType type = 1;
+    /**
+     * ID of the task.
+     */
     required string taskId = 2;
-    required string executorId = 3;
-    required double cpuCores = 4;
-    required int64 memMb = 5;
-    required int64 diskMb = 6;
-    repeated int64 ports = 7;
+    /**
+     * Resources to be provisioned for this task.
+     */
+    required TaskResources resources = 3;
 
-    optional TaskDetails taskDetails = 8;
+    /**
+     * Details for the task - depending on taskType.
+     */
+    optional TaskDetails taskDetails = 4;
 
-    enum TaskType {
+    enum NodeTaskType {
+        /**
+         * Inquire some meta information from the executor.
+         */
         METADATA = 1;
+        /**
+         * Start the Cassandra process.
+         */
         SERVER = 2;
+        /**
+         * Start the node's part of a cluster wide job.
+         */
         CLUSTER_JOB = 3;
         CONFIG = 4;
     }
 }
 
+/**
+ * Details for a task to launch on a node or a task submitted via Mesos framework messages.
+ * Tasks are guaranteed to execute or fail with a status sent to the scheduler.
+ * Framework messages are much like UDP packages - no delivery guarantee - messages might be received
+ * out-of-order.
+ */
 message TaskDetails {
-    required TaskType taskType = 1;
+    /**
+     * Type of the task.
+     */
+    required TaskDetailsType type = 1;
+    /**
+     * ???
+     */
     optional ExecutorMetadataTask executorMetadataTask = 2;
+    /**
+     * Start the Cassandra process.
+     */
     optional CassandraServerRunTask cassandraServerRunTask = 3;
+    /**
+     * Start a node's part of a cluster wide job.
+     */
     optional NodeJobTask nodeJobTask = 4;
     optional UpdateConfigTask updateConfigTask = 5;
 
-    enum TaskType {
+    enum TaskDetailsType {
+        /**
+         * ???
+         * Via launchTask.
+         */
         EXECUTOR_METADATA = 1;
+        /**
+         * Start the Cassandra process.
+         * Via launchTask.
+         */
         CASSANDRA_SERVER_RUN = 2;
+        /**
+         * Ask executor to perform a health check and return the result to its scheduler.
+         * Via framework message from scheduler to executor.
+         */
         HEALTH_CHECK = 3;
+        /**
+         * Start a node's part of a cluster-wide job.
+         * Via launchTask.
+         */
         NODE_JOB = 4;
+        /**
+         * Ask executor to return the status of its current node-job to its scheduler.
+         * Via framework message from scheduler to executor.
+         */
         NODE_JOB_STATUS = 5;
         UPDATE_CONFIG = 6;
     }
 }
 
+/**
+ * ???
+ */
 message ExecutorMetadataTask {
+    /**
+     * ???
+     */
     required string executorId = 1;
+    /**
+     * ???
+     */
     required string ip = 2;
 }
 
+/**
+ * Cassandra process start task.
+ */
 message CassandraServerRunTask {
+    /**
+     * Cassandra version.
+     */
     required string version = 1;
+    /**
+     * Cassandra server process command and arguments.
+     */
     repeated string command = 2;
+    /**
+     * Cassandra server configuration.
+     */
     required CassandraServerConfig cassandraServerConfig = 3;
+    /**
+     * Information how to connect to Cassandra's JMX server.
+     */
     required JmxConnect jmx = 4;
 }
 
@@ -287,19 +658,48 @@ message UpdateConfigTask {
 }
 
 message CassandraServerConfig {
+    /**
+     * Required files.
+     */
     repeated TaskFile taskFiles = 1;
+    /**
+     * Cassandra server process environment.
+     */
     optional TaskEnv taskEnv = 2;
-    required TaskConfig taskConfig = 3;
-
+    /**
+     * Cassandra.yaml configuration details.
+     */
+    required TaskConfig cassandraYamlConfig = 3;
+    /**
+     * Logical location of the node.
+     */
     optional NodeLocation location = 4;
 }
 
+/**
+ * Contains information what kind of cluster job a node should start.
+ */
 message NodeJobTask {
+    /**
+     * Cluster job type.
+     */
     required ClusterJobType jobType = 1;
 }
 
+/**
+ * Information how to connect to Cassandra's JMX server.
+ */
 message JmxConnect {
+    /**
+     * The TCP port the JMX server uses. Usually this port equals to the default port in
+     * CassandraFrameworkConfiguration.portMapping. In a development environment where all nodes are running on
+     * the same machine, the JMX port differs per node (thanks to Sun/Oracle, who didn't made it possible to
+     * bind JMX server to an IP address).
+     */
     required int32 jmxPort = 1;
+    /**
+     * IP address where the JMX server runs. This is usually the IP address of the node.
+     */
     required string ip = 2;
     // TODO add JMX auth params
 }
@@ -309,17 +709,41 @@ message JmxConnect {
  * with provided data
  */
 message TaskFile {
+    /**
+     * Target path name.
+     */
     required string outputPath = 1;
+    /**
+     * File contents.
+     */
     required bytes data = 2;
 }
 
+/**
+ * Configuration for a configuration file - usually cassandra.yaml.
+ */
 message TaskConfig {
+    /**
+     * A single config item.
+     */
     message Entry {
+        /**
+         * Config item name.
+         */
         required string name = 1;
+        /**
+         * Either a string value ...
+         */
         optional string stringValue = 2;
+        /**
+         * ... or an integer value.
+         */
         optional int64 longValue = 3;
     }
 
+    /**
+     * List of config items.
+     */
     repeated Entry variables = 1;
 }
 
@@ -328,19 +752,50 @@ message TaskConfig {
  */
 message TaskEnv {
     message Entry {
+        /**
+         * Environment variable name.
+         */
         required string name = 1;
+        /**
+         * Environment variable value.
+         */
         required string value = 2;
     }
 
+    /**
+     * List of environment variables.
+     */
     repeated Entry variables = 1;
 }
 
+/**
+ * Status details sent back from the executor to the scheduler either as a status-update for a
+ * launched task or as a framework message in reply to a status inquiry.
+ */
 message SlaveStatusDetails {
+    /**
+     * Type of status details.
+     */
     required StatusDetailsType statusDetailsType = 1;
+    /**
+     * ???
+     */
     optional ExecutorMetadata executorMetadata = 2;
+    /**
+     * Information about the launched Cassandra process.
+     */
     optional CassandraServerRunMetadata cassandraServerRunMetadata = 3;
+    /**
+     * Error information.
+     */
     optional SlaveErrorDetails slaveErrorDetails = 4;
+    /**
+     * Health check details (only via framework messages).
+     */
     optional HealthCheckDetails healthCheckDetails = 5;
+    /**
+     * Node job status (only via framework messages).
+     */
     optional NodeJobStatus nodeJobStatus = 6;
 
     enum StatusDetailsType {
@@ -353,20 +808,50 @@ message SlaveStatusDetails {
     }
 }
 
+/**
+ * ???
+ */
 message ExecutorMetadata {
+    /**
+     * ???
+     */
     required string executorId = 1;
+    /**
+     * ???
+     */
     optional string ip = 2;
     required string workdir = 3;
 }
 
+/**
+ * Information about the launched Cassandra process.
+ */
 message CassandraServerRunMetadata {
+    /**
+     * Process ID of the Cassandra process.
+     */
     required int32 pid = 1;
 }
 
+/**
+ * Error information sent as status update from executor to scheduler.
+ */
 message SlaveErrorDetails {
+    /**
+     * Error message.
+     */
     optional string msg = 1;
+    /**
+     * Error details (if available).
+     */
     optional string details = 2;
+    /**
+     * Error type.
+     */
     optional ErrorType errorType = 3;
+    /**
+     * Exit code of the process.
+     */
     optional int32 processExitCode = 4;
 
     enum ErrorType {
@@ -383,26 +868,82 @@ message SlaveErrorDetails {
     }
 }
 
+/**
+ * Health check information.
+ */
 message HealthCheckDetails {
+    /**
+     * Flag whether the Cassandra process can be considered healthy.
+     */
     required bool healthy = 1;
+    /**
+     * May contain reason why the Cassandra process is not considered healthy
+     */
     optional string msg = 2;
+    /**
+     * Optional details.
+     */
     optional NodeInfo info = 3;
 }
 
+/**
+ * Cassandra process information as inquired by JMX.
+ */
 message NodeInfo {
-    // extracted this information because it could be meaningful outside of a health-check
+    /**
+     * Name of the cluster.
+     */
     optional string clusterName = 1;
+    /**
+     * Operation mode as reported by Cassandra.
+     */
     optional string operationMode = 2;
+    /**
+     * Flag whether the node has joined the cluster.
+     */
     optional bool joined = 3;
+    /**
+     * Flag whether the Thrift (RPC) server is running.
+     */
     optional bool rpcServerRunning = 4;
+    /**
+     * Flag whether the native protocol server is running.
+     */
     optional bool nativeTransportRunning = 5;
+    /**
+     * Flag whether gossip is initialized.
+     */
     optional bool gossipInitialized = 6;
+    /**
+     * Flag whether gossip is running.
+     */
     optional bool gossipRunning = 7;
+    /**
+     * Uptime of the JVM in milliseconds.
+     */
     optional int64 uptimeMillis = 8;
+    /**
+     * ID of the Cassandra host.
+     */
     optional string hostId = 9;
+    /**
+     * Endpoint of the Cassandra host.
+     */
     optional string endpoint = 10;
+    /**
+     * Number of tokens managed by this node.
+     */
     optional int32 tokenCount = 11;
+    /**
+     * Name of the data center of this node.
+     */
     optional string dataCenter = 12;
+    /**
+     * Name of the rack of this node.
+     */
     optional string rack = 13;
+    /**
+     * Cassandra version string (as returned by Cassandra).
+     */
     optional string version = 14;
 }

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -21,7 +21,9 @@ option java_outer_classname = "CassandraFrameworkProtos";
  */
 message CassandraFrameworkConfiguration {
     /**
-     * ID of the framework. Assigned by Mesos when the scheduler is registered.
+     * ID of the framework.
+     * Upon initial framework registration Mesos will generate the framework id and return it as part of Scheduler.registered.
+     * The framework will use this value (if set) when it restarts and re-registers with Mesos
      */
     optional string frameworkId = 1;
     /**
@@ -32,36 +34,29 @@ message CassandraFrameworkConfiguration {
      */
     required string frameworkName = 2;
     /**
-     * Name of the Cassandra cluster.
-     * This is different from frameworkName since if you have setup multiple Cassandra-on-Mesos
-     * frameworks for each logical data center (with different frameworkName and frameworkId) you
-     * still have the same Cassandra cluster name.
-     */
-    required string clusterName = 3;
-    /**
      * Minimum interval in seconds to ask each executor for a health check response of the Cassandra
      * server task (= Cassandra process).
      */
-    required int64 healthCheckIntervalSeconds = 4;
+    required int64 healthCheckIntervalSeconds = 3;
     /**
      * Minimum interval in seconds between two starts of a Cassandra server task (= Cassandra process).
      */
-    required int64 bootstrapGraceTimeSeconds = 5;
+    required int64 bootstrapGraceTimeSeconds = 4;
     /**
      * Globally shared mapping of ports required by Cassandra.
      * Currently there are port mappings for these kinds of ports and respective default values:
      * storage_port=7000, ssl_storage_port=7001, native_transport_port=9042, rpc_port=9160, jmx_port=7199
      */
-    repeated PortMapping portMapping = 6;
+    repeated PortMapping portMapping = 5;
     /**
      * The class name of the snitch used. Defaults to GossipingPropertyFileSnitch.
      */
-    optional string snitch = 7;
+    optional string snitch = 6;
 
     /**
      * Default configuration role.
      */
-    required CassandraConfigRole defaultConfigRole = 8;
+    required CassandraConfigRole defaultConfigRole = 7;
 }
 
 /**
@@ -159,7 +154,7 @@ message CassandraClusterState {
      */
     repeated CassandraNode nodes = 1;
     /**
-     * List of all known executors.
+     * List of Metadata collected during executor startup.
      */
     repeated ExecutorMetadata executorMetadata = 2;
     /**
@@ -181,8 +176,6 @@ message CassandraClusterState {
 
 /**
  * Contains a history of the last health-checks that were received from all nodes.
- * The implementation should not add a new entry when it is similar to the previous one.
- * Instead it should update the timespan in the previous one.
  * This is a top-level object in the state hierarchy.
  */
 message CassandraClusterHealthCheckHistory {
@@ -197,7 +190,7 @@ message CassandraClusterHealthCheckHistory {
 }
 
 /**
- * Health check history entry as part of CassandraClusterHealthCheckHistory message.
+ * Represents and time span where the specified executor was in a particular state.
  */
 message HealthCheckHistoryEntry {
     /**
@@ -665,9 +658,7 @@ message NodeJobTask {
 message JmxConnect {
     /**
      * The TCP port the JMX server uses. Usually this port equals to the default port in
-     * CassandraFrameworkConfiguration.portMapping. In a development environment where all nodes are running on
-     * the same machine, the JMX port differs per node (thanks to Sun/Oracle, who didn't made it possible to
-     * bind JMX server to an IP address).
+     * CassandraFrameworkConfiguration.portMapping.
      */
     required int32 jmxPort = 1;
     /**

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -139,11 +139,6 @@ message CassandraConfigRole {
     optional TaskConfig cassandraYamlConfig = 9;
     // mesos role to be used to receive resource offers
     optional string mesosRole = 10;
-
-    /**
-     * The default location for nodes.
-     */
-    optional NodeLocation nodeLocation = 11;
 }
 
 /**
@@ -416,27 +411,9 @@ message CassandraNode {
         TERMINATE = 3;
     }
 
-    /**
-     * Location (data center + rack) of this node.
-     */
-    optional NodeLocation location = 14;
-
     // The configuration files of this node need to be updated, but the Cassandra server process does not
     // need to be restarted.
-    optional bool needsConfigUpdate = 15;
-}
-/**
- * Contains data center + rack information.
- */
-message NodeLocation {
-    /**
-     * Name of the data center.
-     */
-    optional string datacenter = 1;
-    /**
-     * Name of the rack.
-     */
-    optional string rack = 2;
+    optional bool needsConfigUpdate = 14;
 }
 /**
  * Describes a data volume for a node.
@@ -670,10 +647,6 @@ message CassandraServerConfig {
      * Cassandra.yaml configuration details.
      */
     required TaskConfig cassandraYamlConfig = 3;
-    /**
-     * Logical location of the node.
-     */
-    optional NodeLocation location = 4;
 }
 
 /**

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -683,6 +683,7 @@ public final class ApiController {
                     json.setPrettyPrinter(new DefaultPrettyPrinter());
                     json.writeStartObject();
 
+                    json.writeStringField("clusterName", configuration.getFrameworkName());
                     json.writeNumberField("nativePort", nativePort);
                     json.writeNumberField("rpcPort", rpcPort);
                     json.writeNumberField("jmxPort", jmxPort);

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -174,7 +174,7 @@ public final class ApiController {
 
             json.writeStringField("frameworkName", configuration.getFrameworkName());
             json.writeStringField("frameworkId", configuration.getFrameworkId());
-            json.writeStringField("clusterName", configuration.getClusterName());
+            json.writeStringField("clusterName", configuration.getFrameworkName());
 
             CassandraFrameworkProtos.CassandraConfigRole configRole = configuration.getDefaultConfigRole();
             json.writeObjectFieldStart("defaultConfigRole");

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -1160,7 +1160,7 @@ public final class ApiController {
      * "success" : "false",
      * "error" : "Some error message"
      * }}</pre>
-     *  <br/>
+     *  <p></p>
      *  <pre>{@code {
      * "ip" : "127.0.0.1",
      * "hostname" : "localhost",
@@ -1189,7 +1189,7 @@ public final class ApiController {
      * "success" : "false",
      * "error" : "Some error message"
      * }}</pre>
-     *  <br/>
+     *  <p></p>
      *  <pre>{@code {
      * "ip" : "127.0.0.1",
      * "hostname" : "localhost",

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -179,12 +179,12 @@ public final class CassandraCluster {
             }
             CassandraNode.Builder builder = CassandraFrameworkProtosUtils.removeTask(cassandraNode, nodeTask);
             changed = true;
-            switch (nodeTask.getTaskType()) {
+            switch (nodeTask.getType()) {
                 case METADATA:
                     // TODO shouldn't we also assume that the server task is no longer running ??
                     // TODO do we need to remove the executor metadata ??
 
-                    removeExecutorMetadata(nodeTask.getExecutorId());
+                    removeExecutorMetadata(cassandraNode.getCassandraNodeExecutor().getExecutorId());
                     builder.clearTasks();
                     break;
                 case SERVER:
@@ -231,15 +231,6 @@ public final class CassandraCluster {
                 .filter(cassandraNodeForTaskId(taskId))
                 .filter(cassandraNodeHasExecutor())
                 .transform(executorIdFromCassandraNode())
-        );
-    }
-
-    @NotNull
-    public Optional<CassandraNode> getNodeForTask(@NotNull final String taskId) {
-        return headOption(
-            from(clusterState.nodes())
-                .filter(cassandraNodeForTaskId(taskId))
-                .filter(cassandraNodeHasExecutor())
         );
     }
 
@@ -301,7 +292,7 @@ public final class CassandraCluster {
                 //removeTask(nodeOpt.get().getServerTask().getTaskId());
             } else {
                 // upon the first healthy response clear the replacementForIp field
-                CassandraNodeTask serverTask = CassandraFrameworkProtosUtils.getTaskForNode(nodeOpt.get(), CassandraNodeTask.TaskType.SERVER);
+                CassandraNodeTask serverTask = CassandraFrameworkProtosUtils.getTaskForNode(nodeOpt.get(), CassandraNodeTask.NodeTaskType.SERVER);
                 if (serverTask != null && nodeOpt.get().hasReplacementForIp()) {
                     clusterState.nodeReplaced(nodeOpt.get());
                 }
@@ -377,8 +368,8 @@ public final class CassandraCluster {
 
             final CassandraNodeExecutor executor = node.getCassandraNodeExecutor();
             final String executorId = executor.getExecutorId();
-            CassandraNodeTask metadataTask = CassandraFrameworkProtosUtils.getTaskForNode(node.build(), CassandraNodeTask.TaskType.METADATA);
-            CassandraNodeTask serverTask = CassandraFrameworkProtosUtils.getTaskForNode(node.build(), CassandraNodeTask.TaskType.SERVER);
+            CassandraNodeTask metadataTask = CassandraFrameworkProtosUtils.getTaskForNode(node.build(), CassandraNodeTask.NodeTaskType.METADATA);
+            CassandraNodeTask serverTask = CassandraFrameworkProtosUtils.getTaskForNode(node.build(), CassandraNodeTask.NodeTaskType.SERVER);
             if (metadataTask == null) {
                 if (node.getTargetRunState() == CassandraNode.TargetRunState.TERMINATE) {
                     // node completely terminated
@@ -429,7 +420,7 @@ public final class CassandraCluster {
                             boolean anySeedRunning = false;
                             boolean anyNodeInfluencingTopology = false;
                             for (CassandraNode cassandraNode : clusterState.nodes()) {
-                                if (CassandraFrameworkProtosUtils.getTaskForNode(cassandraNode, CassandraNodeTask.TaskType.SERVER) != null) {
+                                if (CassandraFrameworkProtosUtils.getTaskForNode(cassandraNode, CassandraNodeTask.NodeTaskType.SERVER) != null) {
                                     HealthCheckHistoryEntry lastHC = lastHealthCheck(cassandraNode.getCassandraNodeExecutor().getExecutorId());
                                     if (cassandraNode.getSeed()) {
                                         if (lastHC != null && lastHC.getDetails() != null && lastHC.getDetails().getInfo() != null
@@ -461,9 +452,7 @@ public final class CassandraCluster {
                         CassandraConfigRole configRole = configuration.getDefaultConfigRole();
                         final List<String> errors = hasResources(
                                 offer,
-                                configRole.getCpuCores(),
-                                configRole.getMemMb(),
-                                configRole.getDiskMb(),
+                                configRole.getResources(),
                                 portMappings(config),
                                 configRole.getMesosRole()
                         );
@@ -471,7 +460,7 @@ public final class CassandraCluster {
                             LOGGER.info(marker, "Insufficient resources in offer: {}. Details: ['{}']", offer.getId().getValue(), JOINER.join(errors));
                         } else {
                             final ExecutorMetadata metadata = maybeMetadata.get();
-                            final CassandraNodeTask task = getServerTask(executorId, serverTaskId(node), metadata, node);
+                            final CassandraNodeTask task = getServerTask(serverTaskId(node), metadata, node);
                             node.addTasks(task)
                                 .setNeedsConfigUpdate(false);
                             result.getLaunchTasks().add(task);
@@ -480,7 +469,7 @@ public final class CassandraCluster {
                         }
                     } else {
                         if (node.getNeedsConfigUpdate()) {
-                            CassandraNodeTask task = getConfigUpdateTask(executorId, configUpdateTaskId(node), maybeMetadata.get());
+                            CassandraNodeTask task = getConfigUpdateTask(configUpdateTaskId(node), maybeMetadata.get());
                             node.addTasks(task)
                                 .setNeedsConfigUpdate(false);
                             result.getLaunchTasks().add(task);
@@ -525,18 +514,18 @@ public final class CassandraCluster {
 
 
     @NotNull
-    private String executorTaskId(@NotNull CassandraNode.Builder node) {
+    private static String executorTaskId(@NotNull CassandraNode.Builder node) {
         return node.getCassandraNodeExecutor().getExecutorId();
     }
 
     @NotNull
     private static String configUpdateTaskId(CassandraNode.Builder node) {
-        return node.getCassandraNodeExecutor().getExecutorId() + ".config";
+        return executorTaskId(node) + ".config";
     }
 
     @NotNull
     private static String serverTaskId(CassandraNode.Builder node) {
-        return node.getCassandraNodeExecutor().getExecutorId() + ".server";
+        return executorTaskId(node) + ".server";
     }
 
     private boolean canLaunchServerTask() {
@@ -572,6 +561,10 @@ public final class CassandraCluster {
                 .setSeed(seed);
         if (replacementForIp != null) {
             builder.setReplacementForIp(replacementForIp);
+        }
+
+        if (configuration.getDefaultConfigRole().hasNodeLocation()) {
+            builder.setLocation(configuration.getDefaultConfigRole().getNodeLocation());
         }
 
         try {
@@ -630,7 +623,6 @@ public final class CassandraCluster {
 
     @NotNull
     private CassandraNodeTask getConfigUpdateTask(
-        @NotNull final String executorId,
         @NotNull final String taskId,
         @NotNull final ExecutorMetadata metadata) {
         CassandraFrameworkConfiguration config = configuration.get();
@@ -639,27 +631,22 @@ public final class CassandraCluster {
         CassandraServerConfig cassandraServerConfig = buildCassandraServerConfig(metadata, config, configRole, TaskEnv.getDefaultInstance());
 
         final TaskDetails taskDetails = TaskDetails.newBuilder()
-            .setTaskType(TaskDetails.TaskType.UPDATE_CONFIG)
+            .setType(TaskDetails.TaskDetailsType.UPDATE_CONFIG)
             .setUpdateConfigTask(UpdateConfigTask.newBuilder()
                     .setCassandraServerConfig(cassandraServerConfig)
             )
             .build();
 
         return CassandraNodeTask.newBuilder()
-            .setTaskType(CassandraNodeTask.TaskType.CONFIG)
+            .setType(CassandraNodeTask.NodeTaskType.CONFIG)
             .setTaskId(taskId)
-            .setExecutorId(executorId)
-            .setCpuCores(configRole.getCpuCores())
-            .setMemMb(configRole.getMemMb())
-            .setDiskMb(configRole.getDiskMb())
-            .addAllPorts(portMappings(config).values())
+            .setResources(configRole.getResources())
             .setTaskDetails(taskDetails)
             .build();
     }
 
     @NotNull
     private CassandraNodeTask getServerTask(
-        @NotNull final String executorId,
         @NotNull final String taskId,
         @NotNull final ExecutorMetadata metadata,
         @NotNull final CassandraNode.Builder node) {
@@ -679,7 +666,7 @@ public final class CassandraCluster {
         // The example HEAP_NEWSIZE assumes a modern 8-core+ machine for decent pause
         // times. If in doubt, and if you do not particularly want to tweak, go with
         // 100 MB per physical CPU core.
-        CassandraFrameworkProtosUtils.addTaskEnvEntry(taskEnv, false, "HEAP_NEWSIZE", (int) (configRole.getCpuCores() * 100) + "m");
+        CassandraFrameworkProtosUtils.addTaskEnvEntry(taskEnv, false, "HEAP_NEWSIZE", (int) (configRole.getResources().getCpuCores() * 100) + "m");
 
         ArrayList<String> command = newArrayList("apache-cassandra-" + configRole.getCassandraVersion() + "/bin/cassandra", "-f");
         if (node.hasReplacementForIp()) {
@@ -689,7 +676,7 @@ public final class CassandraCluster {
         CassandraServerConfig cassandraServerConfig = buildCassandraServerConfig(metadata, config, configRole, taskEnv.build());
 
         final TaskDetails taskDetails = TaskDetails.newBuilder()
-            .setTaskType(TaskDetails.TaskType.CASSANDRA_SERVER_RUN)
+            .setType(TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN)
             .setCassandraServerRunTask(
                 CassandraServerRunTask.newBuilder()
                     // have to start it in foreground in order to be able to detect runtime status in the executor
@@ -702,13 +689,10 @@ public final class CassandraCluster {
             .build();
 
         return CassandraNodeTask.newBuilder()
-            .setTaskType(CassandraNodeTask.TaskType.SERVER)
+            .setType(CassandraNodeTask.NodeTaskType.SERVER)
             .setTaskId(taskId)
-            .setExecutorId(executorId)
-            .setCpuCores(configRole.getCpuCores())
-            .setMemMb(configRole.getMemMb())
-            .setDiskMb(configRole.getDiskMb())
-            .addAllPorts(portMappings(config).values())
+            .setResources(TaskResources.newBuilder(configRole.getResources())
+                .addAllPorts(portMappings(config).values()))
             .setTaskDetails(taskDetails)
             .build();
     }
@@ -732,7 +716,7 @@ public final class CassandraCluster {
         CassandraFrameworkProtosUtils.setTaskConfig(taskConfig, configValue("endpoint_snitch", config.hasSnitch() ? config.getSnitch() : "GossipingPropertyFileSnitch"));
 
         return CassandraServerConfig.newBuilder()
-            .setTaskConfig(taskConfig)
+            .setCassandraYamlConfig(taskConfig)
             .setTaskEnv(taskEnv)
             .build();
     }
@@ -765,29 +749,27 @@ public final class CassandraCluster {
         return CassandraNodeExecutor.newBuilder()
             .setExecutorId(executorId)
             .setSource(configuration.frameworkName())
-            .setCpuCores(0.1)
-            .setMemMb(384)
-            .setDiskMb(256)
             .addAllCommand(command)
             .setTaskEnv(taskEnvFromMap(executorEnv))
-            .addAllResource(newArrayList(
-                resourceUri(getUrlForResource("/jre-7-" + osName + ".tar.gz"), true),
-                resourceUri(getUrlForResource("/apache-cassandra-" + configRole.getCassandraVersion() + "-bin.tar.gz"), true),
-                resourceUri(getUrlForResource("/cassandra-executor.jar"), false)
+            .setResources(taskResources(0.1, 384, 256))
+            .addAllDownload(newArrayList(
+                resourceFileDownload(getUrlForResource("/jre-7-" + osName + ".tar.gz"), true),
+                resourceFileDownload(getUrlForResource("/apache-cassandra-" + configRole.getCassandraVersion() + "-bin.tar.gz"), true),
+                resourceFileDownload(getUrlForResource("/cassandra-executor.jar"), false)
             ))
             .build();
     }
 
     private static TaskDetails getHealthCheckTaskDetails() {
         return TaskDetails.newBuilder()
-            .setTaskType(TaskDetails.TaskType.HEALTH_CHECK)
+            .setType(TaskDetails.TaskDetailsType.HEALTH_CHECK)
             .build();
     }
 
     @NotNull
     private static CassandraNodeTask getMetadataTask(@NotNull final String executorId, String ip) {
         final TaskDetails taskDetails = TaskDetails.newBuilder()
-            .setTaskType(TaskDetails.TaskType.EXECUTOR_METADATA)
+            .setType(TaskDetails.TaskDetailsType.EXECUTOR_METADATA)
             .setExecutorMetadataTask(
                 ExecutorMetadataTask.newBuilder()
                     .setExecutorId(executorId)
@@ -795,12 +777,9 @@ public final class CassandraCluster {
             )
             .build();
         return CassandraNodeTask.newBuilder()
-            .setTaskType(CassandraNodeTask.TaskType.METADATA)
+            .setType(CassandraNodeTask.NodeTaskType.METADATA)
             .setTaskId(executorId)
-            .setExecutorId(executorId)
-            .setCpuCores(0.1)
-            .setMemMb(32)
-            .setDiskMb(0)
+            .setResources(taskResources(0.1, 32, 0))
             .setTaskDetails(taskDetails)
             .build();
     }
@@ -808,9 +787,7 @@ public final class CassandraCluster {
     @NotNull
     private static List<String> hasResources(
         @NotNull final Protos.Offer offer,
-        final double cpu,
-        final long mem,
-        final long disk,
+        @NotNull final TaskResources resources,
         @NotNull final Map<String, Long> portMapping,
         final String mesosRole
     ) {
@@ -819,18 +796,19 @@ public final class CassandraCluster {
                 .filter(resourceHasExpectedRole(mesosRole))
                 .index(resourceToName());
 
-        final Double availableCpus = resourceValueDouble(headOption(index.get("cpus"))).or(0.0);
-        final Long availableMem = resourceValueLong(headOption(index.get("mem"))).or(0L);
-        final Long availableDisk = resourceValueLong(headOption(index.get("disk"))).or(0L);
 
-        if (availableCpus <= cpu) {
-            errors.add(String.format("Not enough cpu resources for role %s. Required %f only %f available.", mesosRole, cpu, availableCpus));
+        final double availableCpus = resourceValueDouble(headOption(index.get("cpus"))).or(0.0);
+        final long availableMem = resourceValueLong(headOption(index.get("mem"))).or(0L);
+        final long availableDisk = resourceValueLong(headOption(index.get("disk"))).or(0L);
+
+        if (availableCpus <= resources.getCpuCores()) {
+            errors.add(String.format("Not enough cpu resources for role %s. Required %f only %f available.", mesosRole, resources.getCpuCores(), availableCpus));
         }
-        if (availableMem <= mem) {
-            errors.add(String.format("Not enough mem resources for role %s. Required %d only %d available", mesosRole, mem, availableMem));
+        if (availableMem <= resources.getMemMb()) {
+            errors.add(String.format("Not enough mem resources for role %s. Required %d only %d available", mesosRole, resources.getMemMb(), availableMem));
         }
-        if (availableDisk <= disk) {
-            errors.add(String.format("Not enough disk resources for role %s. Required %d only %d available", mesosRole, disk, availableDisk));
+        if (availableDisk <= resources.getDiskMb()) {
+            errors.add(String.format("Not enough disk resources for role %s. Required %d only %d available", mesosRole, resources.getDiskMb(), availableDisk));
         }
 
         final TreeSet<Long> ports = resourceValueRange(headOption(index.get("ports")));
@@ -1038,7 +1016,7 @@ public final class CassandraCluster {
         if (!node.hasCassandraNodeExecutor()) {
             return false;
         }
-        if (getTaskForNode(node, CassandraNodeTask.TaskType.SERVER) == null) {
+        if (getTaskForNode(node, CassandraNodeTask.NodeTaskType.SERVER) == null) {
             return false;
         }
         HealthCheckHistoryEntry hc = lastHealthCheck(node.getCassandraNodeExecutor().getExecutorId());
@@ -1123,5 +1101,13 @@ public final class CassandraCluster {
             .setSeed(seed));
 
         return true;
+    }
+
+    private static TaskResources taskResources(double cpuCores, long memMb, long diskMb) {
+        return TaskResources.newBuilder()
+            .setCpuCores(cpuCores)
+            .setMemMb(memMb)
+            .setDiskMb(diskMb)
+            .build();
     }
 }

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -563,10 +563,6 @@ public final class CassandraCluster {
             builder.setReplacementForIp(replacementForIp);
         }
 
-        if (configuration.getDefaultConfigRole().hasNodeLocation()) {
-            builder.setLocation(configuration.getDefaultConfigRole().getNodeLocation());
-        }
-
         try {
             InetAddress ia = InetAddress.getByName(offer.getHostname());
 

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/NodeTaskClusterJobHandler.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/NodeTaskClusterJobHandler.java
@@ -34,7 +34,7 @@ public class NodeTaskClusterJobHandler extends ClusterJobHandler {
             if (executorId.equals(nodJobStatus.getExecutorId())) {
                 // submit status request
                 tasksForOffer.getSubmitTasks().add(CassandraFrameworkProtos.TaskDetails.newBuilder()
-                    .setTaskType(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB_STATUS)
+                    .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS)
                     .build());
 
                 LOGGER.info("Inquiring cluster job status for {} from {}", currentJob.getJobType().name(),
@@ -74,22 +74,22 @@ public class NodeTaskClusterJobHandler extends ClusterJobHandler {
             CassandraFrameworkProtos.CassandraNode node = nodeForExecutorId.get();
 
             final CassandraFrameworkProtos.TaskDetails taskDetails = CassandraFrameworkProtos.TaskDetails.newBuilder()
-                .setTaskType(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB)
+                .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB)
                 .setNodeJobTask(CassandraFrameworkProtos.NodeJobTask.newBuilder().setJobType(currentJob.getJobType()))
                 .build();
             CassandraFrameworkProtos.CassandraNodeTask cassandraNodeTask = CassandraFrameworkProtos.CassandraNodeTask.newBuilder()
-                .setTaskType(CassandraFrameworkProtos.CassandraNodeTask.TaskType.CLUSTER_JOB)
+                .setType(CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.CLUSTER_JOB)
                 .setTaskId(executorId + '.' + currentJob.getJobType().name())
-                .setExecutorId(executorId)
-                .setCpuCores(0.1)
-                .setMemMb(16)
-                .setDiskMb(16)
+                .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
+                    .setCpuCores(0.1)
+                    .setMemMb(16)
+                    .setDiskMb(16))
                 .setTaskDetails(taskDetails)
                 .build();
             tasksForOffer.getLaunchTasks().add(cassandraNodeTask);
 
             CassandraFrameworkProtos.NodeJobStatus currentNode = CassandraFrameworkProtos.NodeJobStatus.newBuilder()
-                .setExecutorId(cassandraNodeTask.getExecutorId())
+                .setExecutorId(node.getCassandraNodeExecutor().getExecutorId())
                 .setTaskId(cassandraNodeTask.getTaskId())
                 .setJobType(currentJob.getJobType())
                 .setStartedTimestamp(System.currentTimeMillis())

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterHealthCheckHistory.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterHealthCheckHistory.java
@@ -89,6 +89,10 @@ final class PersistedCassandraClusterHealthCheckHistory extends StatePersistedOb
         return null;
     }
 
+    /**
+     * The implementation does not add a new entry when it is similar to the previous one.
+     * Instead it updates the timespan in the previous one.
+     */
     public void record(String executorId, long timestamp, @NotNull final CassandraFrameworkProtos.HealthCheckDetails healthCheckDetails) {
         CassandraFrameworkProtos.CassandraClusterHealthCheckHistory prev = get();
         int maxEntriesPerNode = prev.getMaxEntriesPerNode();

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterState.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterState.java
@@ -26,7 +26,10 @@ import java.util.List;
 import static io.mesosphere.mesos.util.Functions.append;
 
 final class PersistedCassandraClusterState extends StatePersistedObject<CassandraFrameworkProtos.CassandraClusterState> {
-    public PersistedCassandraClusterState(@NotNull final State state, @NotNull final CassandraFrameworkProtos.CassandraConfigRole defaultConfigRole) {
+    public PersistedCassandraClusterState(
+            @NotNull final State state,
+            final int executorCount,
+            final int seedCount) {
         super(
             "CassandraClusterState",
             state,
@@ -34,8 +37,8 @@ final class PersistedCassandraClusterState extends StatePersistedObject<Cassandr
                 @Override
                 public CassandraFrameworkProtos.CassandraClusterState get() {
                     return CassandraFrameworkProtos.CassandraClusterState.newBuilder()
-                        .setNodesToAcquire(defaultConfigRole.getNumberOfNodes())
-                        .setSeedsToAcquire(defaultConfigRole.getNumberOfSeeds())
+                        .setNodesToAcquire(executorCount)
+                        .setSeedsToAcquire(seedCount)
                         .build();
                 }
             },

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraFrameworkConfiguration.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraFrameworkConfiguration.java
@@ -28,10 +28,16 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
     public PersistedCassandraFrameworkConfiguration(
         @NotNull final State state,
         @NotNull final String frameworkName,
-        @NotNull final String clusterName,
-        @NotNull final CassandraFrameworkProtos.CassandraConfigRole defaultConfigRole,
         final long healthCheckIntervalSeconds,
-        final long bootstrapGraceTimeSec
+        final long bootstrapGraceTimeSec,
+        final String cassandraVersion,
+        final double cpuCores,
+        final long diskMb,
+        final long memMb,
+        final long javeHeapMb,
+        final int executorCount,
+        final int seedCount,
+        final String mesosRole
     ) {
         super(
             "CassandraFrameworkConfiguration",
@@ -39,10 +45,21 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
             new Supplier<CassandraFrameworkConfiguration>() {
                 @Override
                 public CassandraFrameworkConfiguration get() {
+                    CassandraFrameworkProtos.CassandraConfigRole.Builder configRole = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+                        .setCassandraVersion(cassandraVersion)
+                        .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
+                            .setCpuCores(cpuCores)
+                            .setDiskMb(diskMb)
+                            .setMemMb(memMb))
+                        .setNumberOfNodes(executorCount)
+                        .setNumberOfSeeds(seedCount)
+                        .setMesosRole(mesosRole);
+                    if (javeHeapMb > 0) {
+                        configRole.setMemJavaHeapMb(javeHeapMb);
+                    }
                     return CassandraFrameworkConfiguration.newBuilder()
                         .setFrameworkName(frameworkName)
-                        .setClusterName(clusterName)
-                        .setDefaultConfigRole(fillConfigRoleGaps(defaultConfigRole))
+                        .setDefaultConfigRole(fillConfigRoleGaps(configRole))
                         .setHealthCheckIntervalSeconds(healthCheckIntervalSeconds)
                         .setBootstrapGraceTimeSeconds(bootstrapGraceTimeSec)
                         .build();
@@ -67,32 +84,31 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
         );
     }
 
-    public static CassandraFrameworkProtos.CassandraConfigRole fillConfigRoleGaps(CassandraFrameworkProtos.CassandraConfigRole configRole) {
-        CassandraFrameworkProtos.CassandraConfigRole.Builder builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder(configRole);
-        long memMb = builder.getResources().getMemMb();
+    public static CassandraFrameworkProtos.CassandraConfigRole.Builder fillConfigRoleGaps(CassandraFrameworkProtos.CassandraConfigRole.Builder configRole) {
+        long memMb = configRole.getResources().getMemMb();
         if (memMb > 0L) {
-            if (!builder.hasMemJavaHeapMb()) {
-                builder.setMemJavaHeapMb(Math.min(memMb / 2, 16384));
+            if (!configRole.hasMemJavaHeapMb()) {
+                configRole.setMemJavaHeapMb(Math.min(memMb / 2, 16384));
             }
-            if (!builder.hasMemAssumeOffHeapMb()) {
-                builder.setMemAssumeOffHeapMb(memMb - builder.getMemJavaHeapMb());
+            if (!configRole.hasMemAssumeOffHeapMb()) {
+                configRole.setMemAssumeOffHeapMb(memMb - configRole.getMemJavaHeapMb());
             }
         } else  {
-            if (builder.hasMemJavaHeapMb()) {
-                if (!builder.hasMemAssumeOffHeapMb()) {
-                    builder.setMemAssumeOffHeapMb(builder.getMemJavaHeapMb());
+            if (configRole.hasMemJavaHeapMb()) {
+                if (!configRole.hasMemAssumeOffHeapMb()) {
+                    configRole.setMemAssumeOffHeapMb(configRole.getMemJavaHeapMb());
                 }
             } else {
-                if (builder.hasMemAssumeOffHeapMb()) {
-                    builder.setMemJavaHeapMb(builder.getMemAssumeOffHeapMb());
+                if (configRole.hasMemAssumeOffHeapMb()) {
+                    configRole.setMemJavaHeapMb(configRole.getMemAssumeOffHeapMb());
                 } else {
                     throw new IllegalArgumentException("Config role is missing memory configuration");
                 }
             }
-            builder.setResources(CassandraFrameworkProtos.TaskResources.newBuilder(builder.getResources())
-                .setMemMb(builder.getMemJavaHeapMb() + builder.getMemAssumeOffHeapMb()));
+            configRole.setResources(CassandraFrameworkProtos.TaskResources.newBuilder(configRole.getResources())
+                .setMemMb(configRole.getMemJavaHeapMb() + configRole.getMemAssumeOffHeapMb()));
         }
-        return builder.build();
+        return configRole;
     }
 
     @NotNull

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/RestartClusterJobHandler.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/RestartClusterJobHandler.java
@@ -44,7 +44,7 @@ public class RestartClusterJobHandler extends ClusterJobHandler {
 
                         CassandraFrameworkProtos.HealthCheckHistoryEntry lastHC = cluster.lastHealthCheck(executorId);
 
-                        if (CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER) != null &&
+                        if (CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER) != null &&
                             lastHC.hasTimestampEnd() &&
                             lastHC.getTimestampEnd() > nodeJobStatus.getStartedTimestamp() &&
                             cluster.isLiveNode(lastHC)) {

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractSchedulerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractSchedulerTest.java
@@ -47,17 +47,19 @@ public abstract class AbstractSchedulerTest {
 
         CassandraFrameworkProtos.CassandraConfigRole defaultConfigRole = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
             .setCassandraVersion("2.1.2")
-            .setCpuCores(2)
-            .setDiskMb(4096)
+            .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
+                .setCpuCores(2)
+                .setDiskMb(4096)
+                .setMemMb(4096))
             .setMesosRole("*")
             .setNumberOfNodes(3)
             .setNumberOfSeeds(2)
             .setName("default")
-            .setMemMb(4096)
             .setMesosRole("*")
             .build();
         configuration = new PersistedCassandraFrameworkConfiguration(
                 state,
+                "test-cluster",
                 "test-cluster",
                 defaultConfigRole,
                 0, // health-check

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractSchedulerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractSchedulerTest.java
@@ -45,31 +45,21 @@ public abstract class AbstractSchedulerTest {
         // start with clean state
         state = new InMemoryState();
 
-        CassandraFrameworkProtos.CassandraConfigRole defaultConfigRole = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
-            .setCassandraVersion("2.1.2")
-            .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
-                .setCpuCores(2)
-                .setDiskMb(4096)
-                .setMemMb(4096))
-            .setMesosRole("*")
-            .setNumberOfNodes(3)
-            .setNumberOfSeeds(2)
-            .setName("default")
-            .setMesosRole("*")
-            .build();
         configuration = new PersistedCassandraFrameworkConfiguration(
                 state,
                 "test-cluster",
-                "test-cluster",
-                defaultConfigRole,
                 0, // health-check
-                0 // bootstrap-grace-time
+                0, // bootstrap-grace-time
+                "2.1.2",
+            2, 4096, 4096, 0,
+            3, 2,
+            "*"
         );
 
         cluster = new CassandraCluster(new SystemClock(),
                 "http://127.0.0.1:65535",
                 new ExecutorCounter(state, 0L),
-                new PersistedCassandraClusterState(state, defaultConfigRole),
+                new PersistedCassandraClusterState(state, 3, 2),
                 new PersistedCassandraClusterHealthCheckHistory(state),
                 new PersistedCassandraClusterJobs(state),
                 configuration);

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
@@ -226,10 +226,8 @@ public class ApiControllerTest extends AbstractSchedulerTest {
                 CassandraFrameworkProtos.CassandraNodeExecutor.newBuilder(CassandraFrameworkProtos.CassandraNodeExecutor.getDefaultInstance())
                     .setExecutorId(executorId)
                     .setSource("source")
-                    .setCpuCores(1)
-                    .setMemMb(1)
-                    .setDiskMb(1)
                     .addCommand("comand")
+                    .setResources(someResources())
             )
             .setHostname(ip)
             .setIp(ip)
@@ -239,12 +237,9 @@ public class ApiControllerTest extends AbstractSchedulerTest {
                 .setIp(ip)
                 .setJmxPort(7199))
             .addTasks(CassandraFrameworkProtos.CassandraNodeTask.newBuilder()
-                .setExecutorId(executorId)
                 .setTaskId(executorId + ".server")
-                .setTaskType(CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER)
-                .setCpuCores(1)
-                .setMemMb(1)
-                .setDiskMb(1))
+                .setType(CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER)
+                .setResources(someResources()))
             .build());
         cluster.recordHealthCheck(executorId, healthCheckDetailsSuccess("NORMAL", true));
     }
@@ -362,6 +357,14 @@ public class ApiControllerTest extends AbstractSchedulerTest {
         } else {
             throw new IllegalArgumentException("InetAddress type: " + inetAddress.getClass().getName() + " is not supported");
         }
+    }
+
+    private static CassandraFrameworkProtos.TaskResources someResources() {
+        return CassandraFrameworkProtos.TaskResources.newBuilder()
+            .setCpuCores(1)
+            .setMemMb(1)
+            .setDiskMb(1)
+            .build();
     }
 
 }

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraClusterStateTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraClusterStateTest.java
@@ -163,7 +163,7 @@ public class CassandraClusterStateTest extends AbstractSchedulerTest {
         // cluster now up with 3 running nodes
 
         // server-task no longer running
-        CassandraFrameworkProtos.CassandraNodeTask serverTask = CassandraFrameworkProtosUtils.getTaskForNode(cluster.cassandraNodeForHostname(slaves[0]._2).get(), CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER);
+        CassandraFrameworkProtos.CassandraNodeTask serverTask = CassandraFrameworkProtosUtils.getTaskForNode(cluster.cassandraNodeForHostname(slaves[0]._2).get(), CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
         assertNotNull(serverTask);
         cluster.removeTask(serverTask.getTaskId(), null);
 
@@ -172,14 +172,14 @@ public class CassandraClusterStateTest extends AbstractSchedulerTest {
     }
 
     private CassandraFrameworkProtos.ExecutorMetadata launchServer(CassandraCluster cluster, Tuple2<Protos.SlaveID, String> slave) {
-        return launchTask(cluster, slave, -1, CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
+        return launchTask(cluster, slave, -1, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
     }
 
     private CassandraFrameworkProtos.ExecutorMetadata launchExecutor(CassandraCluster cluster, Tuple2<Protos.SlaveID, String> slave, int nodeCount) {
-        return launchTask(cluster, slave, nodeCount, CassandraFrameworkProtos.TaskDetails.TaskType.EXECUTOR_METADATA);
+        return launchTask(cluster, slave, nodeCount, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.EXECUTOR_METADATA);
     }
 
-    private CassandraFrameworkProtos.ExecutorMetadata launchTask(CassandraCluster cluster, Tuple2<Protos.SlaveID, String> slave, int nodeCount, CassandraFrameworkProtos.TaskDetails.TaskType taskType) {
+    private CassandraFrameworkProtos.ExecutorMetadata launchTask(CassandraCluster cluster, Tuple2<Protos.SlaveID, String> slave, int nodeCount, CassandraFrameworkProtos.TaskDetails.TaskDetailsType taskType) {
         Protos.Offer offer = createOffer(slave);
         TasksForOffer tasksForOffer = cluster.getTasksForOffer(offer);
 
@@ -190,7 +190,7 @@ public class CassandraClusterStateTest extends AbstractSchedulerTest {
         assertEquals(0, tasksForOffer.getSubmitTasks().size());
 
         CassandraFrameworkProtos.CassandraNodeTask launchTask = tasksForOffer.getLaunchTasks().get(0);
-        assertEquals(taskType, launchTask.getTaskDetails().getTaskType());
+        assertEquals(taskType, launchTask.getTaskDetails().getType());
         return executorMetadataFor(slave, tasksForOffer.getExecutor().getExecutorId());
     }
 

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraConfigRoleTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraConfigRoleTest.java
@@ -20,7 +20,11 @@ import static org.assertj.core.api.Assertions.*;
 public class CassandraConfigRoleTest {
     @Test(expected = IllegalArgumentException.class)
     public void testMemoryParametersNone() {
-        CassandraFrameworkProtos.CassandraConfigRole.Builder builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder();
+        CassandraFrameworkProtos.CassandraConfigRole.Builder builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+            .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
+                .setMemMb(0)
+                .setDiskMb(1)
+                .setCpuCores(1));
         PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
     }
 
@@ -30,40 +34,58 @@ public class CassandraConfigRoleTest {
         CassandraFrameworkProtos.CassandraConfigRole configRole;
 
         builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
-            .setMemMb(8192);
+            .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
+                .setMemMb(8192)
+                .setDiskMb(1)
+                .setCpuCores(1));
         configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
-        assertThat(configRole.getMemMb()).isEqualTo(8192);
+        assertThat(configRole.getResources().getMemMb()).isEqualTo(8192);
         assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
         assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
 
         builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+            .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
+                .setMemMb(0)
+                .setDiskMb(1)
+                .setCpuCores(1))
             .setMemJavaHeapMb(4096);
         configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
-        assertThat(configRole.getMemMb()).isEqualTo(8192);
+        assertThat(configRole.getResources().getMemMb()).isEqualTo(8192);
         assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
         assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
 
         builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+            .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
+                .setMemMb(0)
+                .setDiskMb(1)
+                .setCpuCores(1))
             .setMemAssumeOffHeapMb(4096);
         configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
-        assertThat(configRole.getMemMb()).isEqualTo(8192);
+        assertThat(configRole.getResources().getMemMb()).isEqualTo(8192);
         assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
         assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
 
         builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
+            .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
+                .setMemMb(0)
+                .setDiskMb(1)
+                .setCpuCores(1))
             .setMemJavaHeapMb(4096)
             .setMemAssumeOffHeapMb(4096);
         configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
-        assertThat(configRole.getMemMb()).isEqualTo(8192);
+        assertThat(configRole.getResources().getMemMb()).isEqualTo(8192);
         assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
         assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
 
         builder = CassandraFrameworkProtos.CassandraConfigRole.newBuilder()
-            .setMemMb(10000)
+            .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
+                .setMemMb(10000)
+                .setDiskMb(1)
+                .setCpuCores(1))
             .setMemJavaHeapMb(4096)
             .setMemAssumeOffHeapMb(4096);
         configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
-        assertThat(configRole.getMemMb()).isEqualTo(10000);
+        assertThat(configRole.getResources().getMemMb()).isEqualTo(10000);
         assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
         assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
     }

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraConfigRoleTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraConfigRoleTest.java
@@ -25,7 +25,7 @@ public class CassandraConfigRoleTest {
                 .setMemMb(0)
                 .setDiskMb(1)
                 .setCpuCores(1));
-        PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
+        PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder).build();
     }
 
     @Test()
@@ -38,7 +38,7 @@ public class CassandraConfigRoleTest {
                 .setMemMb(8192)
                 .setDiskMb(1)
                 .setCpuCores(1));
-        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
+        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder).build();
         assertThat(configRole.getResources().getMemMb()).isEqualTo(8192);
         assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
         assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
@@ -49,7 +49,7 @@ public class CassandraConfigRoleTest {
                 .setDiskMb(1)
                 .setCpuCores(1))
             .setMemJavaHeapMb(4096);
-        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
+        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder).build();
         assertThat(configRole.getResources().getMemMb()).isEqualTo(8192);
         assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
         assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
@@ -60,7 +60,7 @@ public class CassandraConfigRoleTest {
                 .setDiskMb(1)
                 .setCpuCores(1))
             .setMemAssumeOffHeapMb(4096);
-        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
+        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder).build();
         assertThat(configRole.getResources().getMemMb()).isEqualTo(8192);
         assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
         assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
@@ -72,7 +72,7 @@ public class CassandraConfigRoleTest {
                 .setCpuCores(1))
             .setMemJavaHeapMb(4096)
             .setMemAssumeOffHeapMb(4096);
-        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
+        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder).build();
         assertThat(configRole.getResources().getMemMb()).isEqualTo(8192);
         assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
         assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);
@@ -84,7 +84,7 @@ public class CassandraConfigRoleTest {
                 .setCpuCores(1))
             .setMemJavaHeapMb(4096)
             .setMemAssumeOffHeapMb(4096);
-        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder.build());
+        configRole = PersistedCassandraFrameworkConfiguration.fillConfigRoleGaps(builder).build();
         assertThat(configRole.getResources().getMemMb()).isEqualTo(10000);
         assertThat(configRole.getMemAssumeOffHeapMb()).isEqualTo(4096);
         assertThat(configRole.getMemJavaHeapMb()).isEqualTo(4096);

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraSchedulerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraSchedulerTest.java
@@ -49,25 +49,20 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         node.setCassandraNodeExecutor(CassandraFrameworkProtos.CassandraNodeExecutor.newBuilder()
             .addCommand("cmd")
-            .setCpuCores(1)
-            .setDiskMb(1)
-            .setMemMb(1)
+            .setResources(someResources())
             .setExecutorId("exec")
             .setSource("src"));
 
         assertTrue(node.hasCassandraNodeExecutor());
-        assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node.build(), CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+        assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node.build(), CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
         assertFalse(cluster.isLiveNode(node.build()));
 
         node.addTasks(CassandraFrameworkProtos.CassandraNodeTask.newBuilder()
-            .setCpuCores(1)
-            .setDiskMb(1)
-            .setMemMb(1)
-            .setExecutorId("exec")
+            .setResources(someResources())
             .setTaskId("task")
-            .setTaskType(CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+            .setType(CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
 
-        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node.build(), CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node.build(), CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
         assertFalse(cluster.isLiveNode(node.build()));
 
         CassandraFrameworkProtos.HealthCheckDetails.Builder hcd = CassandraFrameworkProtos.HealthCheckDetails.newBuilder()
@@ -117,18 +112,13 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
             .setJmxConnect(CassandraFrameworkProtos.JmxConnect.newBuilder().setIp("1.2.3.4").setJmxPort(7199))
             .setCassandraNodeExecutor(CassandraFrameworkProtos.CassandraNodeExecutor.newBuilder()
                 .addCommand("cmd")
-                .setCpuCores(1)
-                .setDiskMb(1)
-                .setMemMb(1)
+                .setResources(someResources())
                 .setExecutorId("exec")
                 .setSource("src"))
             .addTasks(CassandraFrameworkProtos.CassandraNodeTask.newBuilder()
-                .setCpuCores(1)
-                .setDiskMb(1)
-                .setMemMb(1)
-                .setExecutorId("exec")
+                .setResources(someResources())
                 .setTaskId("task")
-                .setTaskType(CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+                .setType(CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
         cluster.getClusterState().addOrSetNode(node.build());
         CassandraFrameworkProtos.HealthCheckDetails.Builder hcd = CassandraFrameworkProtos.HealthCheckDetails.newBuilder()
             .setHealthy(true)
@@ -206,7 +196,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         assertNotNull(node3);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.TERMINATE, node3.getTargetRunState());
 
-        CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node3, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER);
+        CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node3, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
         assertNotNull(taskForNode);
 
         // verify that kill-task is launched
@@ -329,9 +319,9 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         }
 
         // verify UPDATE_CONFIG tasks are launched
-        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskType.UPDATE_CONFIG);
-        launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskType.UPDATE_CONFIG);
-        launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskType.UPDATE_CONFIG);
+        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
+        launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
+        launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
         noopOnOffer(slaves[0], 3);
         noopOnOffer(slaves[1], 3);
         noopOnOffer(slaves[2], 3);
@@ -347,9 +337,9 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         }
 
         // verify UPDATE_CONFIG tasks are launched
-        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskType.UPDATE_CONFIG);
-        launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskType.UPDATE_CONFIG);
-        launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskType.UPDATE_CONFIG);
+        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
+        launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
+        launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
         noopOnOffer(slaves[0], 3);
         noopOnOffer(slaves[1], 3);
         noopOnOffer(slaves[2], 3);
@@ -384,7 +374,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.STOP, node1.getTargetRunState());
 
-        CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER);
+        CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
         assertNotNull(taskForNode);
 
         // verify that kill-task is launched
@@ -395,7 +385,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         // re-check that server-task is still present
         node1 = cluster.findNode(slaves[0]._2);
         assertNotNull(node1);
-        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
 
         // simulate server-task has finished
         executorTaskFinished(executorServer[0]._1, CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
@@ -405,7 +395,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         // check that server-task is no longer present
         node1 = cluster.findNode(slaves[0]._2);
         assertNotNull(node1);
-        assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+        assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
 
 
         // now start node
@@ -415,7 +405,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RUN, node1.getTargetRunState());
 
         // verify that CASSANDRA_SERVER_RUN task is launched
-        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
+        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
         // must not repeat CASSANDRA_SERVER_RUN since it's already launched
         noopOnOffer(slaves[0], 3);
 
@@ -423,7 +413,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         node1 = cluster.findNode(slaves[0]._2);
         assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RUN, node1.getTargetRunState());
-        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
 
         // simulate server-task is running
         sendHealthCheckResult(executorMetadata[0], healthCheckDetailsSuccess("NORMAL", true));
@@ -445,7 +435,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node1.getTargetRunState());
 
-        CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER);
+        CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
         assertNotNull(taskForNode);
 
         // verify that kill-task is launched
@@ -457,7 +447,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         node1 = cluster.findNode(slaves[0]._2);
         assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node1.getTargetRunState());
-        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
 
         // simulate server-task has finished
         executorTaskFinished(executorServer[0]._1, CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
@@ -468,11 +458,11 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         node1 = cluster.findNode(slaves[0]._2);
         assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node1.getTargetRunState());
-        assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+        assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
 
 
         // verify that CASSANDRA_SERVER_RUN task is launched
-        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
+        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
         // must not repeat CASSANDRA_SERVER_RUN since it's already launched
         noopOnOffer(slaves[0], 3);
 
@@ -480,7 +470,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         node1 = cluster.findNode(slaves[0]._2);
         assertNotNull(node1);
         assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RUN, node1.getTargetRunState());
-        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
 
         // simulate server-task is running
         sendHealthCheckResult(executorMetadata[0], healthCheckDetailsSuccess("NORMAL", true));
@@ -547,8 +537,8 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         // node must not start (it's not a seed node and no seed node is running)
         noopOnOffer(slaves[2], 3);
 
-        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
-        launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
+        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+        launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
         // still - not able to start node #3
         noopOnOffer(slaves[2], 3);
 
@@ -593,7 +583,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         assertThat(lastHealthCheckDetails(executorMetadata2))
             .isNot(healthy());
         // node#3 can start now
-        launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
+        launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
 
     }
 
@@ -610,7 +600,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         // server-task cannot start again
         launchExecutor(slaves[0], 3);
         executorTaskRunning(executorMetadata[0]);
-        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
+        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
 
     }
 
@@ -661,7 +651,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
             assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node.getTargetRunState());
 
             // simulate server-task stopped
-            CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER);
+            CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
             assertNotNull(taskForNode);
 
             Tuple2<Protos.SlaveID, String> slave = slaveForExecutor(restartingExecutor);
@@ -684,7 +674,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
             // check that server-task is no longer present
             node = cluster.findNode(restartingExecutor);
             assertNotNull(node);
-            assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+            assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
 
             // must have current-node - server task not running
             currentClusterJob = cluster.getCurrentClusterJob();
@@ -693,7 +683,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
             assertEquals(restartingExecutor, currentClusterJob.getCurrentNode().getExecutorId());
 
             // verify that CASSANDRA_SERVER_RUN task is launched
-            launchTask(slave, CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
+            launchTask(slave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
             // must not repeat CASSANDRA_SERVER_RUN since it's already launched
             noopOnOffer(slave, 3, true);
 
@@ -728,7 +718,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         // stop node 2
         CassandraFrameworkProtos.CassandraNode node2 = cluster.nodeStop(slaves[1]._2);
         assertNotNull(node2);
-        CassandraFrameworkProtos.CassandraNodeTask node1serverTask = CassandraFrameworkProtosUtils.getTaskForNode(node2, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER);
+        CassandraFrameworkProtos.CassandraNodeTask node1serverTask = CassandraFrameworkProtosUtils.getTaskForNode(node2, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
         assertNotNull(node1serverTask);
         killTask(slaves[1], node1serverTask.getTaskId());
         // simulate server-task has finished
@@ -777,7 +767,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
             assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node.getTargetRunState());
 
             // simulate server-task stopped
-            CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER);
+            CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
             assertNotNull(taskForNode);
 
             Tuple2<Protos.SlaveID, String> slave = slaveForExecutor(restartingExecutor);
@@ -800,7 +790,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
             // check that server-task is no longer present
             node = cluster.findNode(restartingExecutor);
             assertNotNull(node);
-            assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.TaskType.SERVER));
+            assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
 
             // must have current-node - server task not running
             currentClusterJob = cluster.getCurrentClusterJob();
@@ -809,7 +799,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
             assertEquals(restartingExecutor, currentClusterJob.getCurrentNode().getExecutorId());
 
             // verify that CASSANDRA_SERVER_RUN task is launched
-            launchTask(slave, CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
+            launchTask(slave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
             // must not repeat CASSANDRA_SERVER_RUN since it's already launched
             noopOnOffer(slave, 3, true);
 
@@ -889,7 +879,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         assertFalse(currentClusterJob.hasFinishedTimestamp());
 
         // launch job on a node
-        Protos.TaskInfo taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB);
+        Protos.TaskInfo taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
         Protos.TaskInfo taskInfo1 = taskInfo;
         assertNotNull(taskInfo);
         assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
@@ -923,7 +913,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // check job status submit
 
-        CassandraFrameworkProtos.TaskDetails taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB_STATUS);
+        CassandraFrameworkProtos.TaskDetails taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS);
         assertNotNull(taskDetails);
 
         // simulate job status response
@@ -963,7 +953,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // node has finished ...
 
-        taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB_STATUS);
+        taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS);
         assertNotNull(taskDetails);
 
         finishJob(currentClusterJob, taskInfo, currentSlave, nodeJobStatus, clusterJobType);
@@ -984,7 +974,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // 2nd node
 
-        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB);
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
         assertNotNull(taskInfo);
         Protos.TaskInfo taskInfo2 = taskInfo;
         Assert.assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
@@ -1021,7 +1011,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // 3rd node
 
-        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB);
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
         assertNotNull(taskInfo);
         Assert.assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
         Assert.assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
@@ -1085,7 +1075,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         assertFalse(currentClusterJob.hasFinishedTimestamp());
 
         // launch job on a node
-        Protos.TaskInfo taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB);
+        Protos.TaskInfo taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
         Protos.TaskInfo taskInfo1 = taskInfo;
         assertNotNull(taskInfo);
         assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
@@ -1119,7 +1109,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // check job status submit
 
-        CassandraFrameworkProtos.TaskDetails taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB_STATUS);
+        CassandraFrameworkProtos.TaskDetails taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS);
         assertNotNull(taskDetails);
 
         // simulate job status response
@@ -1159,7 +1149,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // node has finished ...
 
-        taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB_STATUS);
+        taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS);
         assertNotNull(taskDetails);
 
         finishJob(currentClusterJob, taskInfo, currentSlave, nodeJobStatus, clusterJobType);
@@ -1174,7 +1164,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // 2nd node
 
-        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB);
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
         assertNotNull(taskInfo);
         Protos.TaskInfo taskInfo2 = taskInfo;
         Assert.assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
@@ -1205,7 +1195,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
 
         // 3rd node
 
-        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskType.NODE_JOB);
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
         assertNotNull(taskInfo);
         Assert.assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
         Assert.assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
@@ -1323,7 +1313,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         executorMetadata[3] = launchExecutor(slaves[3], 4);
         executorTaskRunning(executorMetadata[3]);
 
-        executorServer[3] = launchTask(slaves[3], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
+        executorServer[3] = launchTask(slaves[3], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
     }
 
     private Protos.TaskInfo[] threeNodeCluster() throws InvalidProtocolBufferException {
@@ -1350,8 +1340,8 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         //noinspection unchecked
         executorServer = new Tuple2[slaves.length];
 
-        executorServer[0] = launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
-        executorServer[1] = launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
+        executorServer[0] = launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+        executorServer[1] = launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
 
         executorTaskRunning(executorServer[0]._1);
         executorTaskRunning(executorServer[1]._1);
@@ -1359,7 +1349,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         sendHealthCheckResult(executorMetadata[0], healthCheckDetailsSuccess("NORMAL", true));
         sendHealthCheckResult(executorMetadata[1], healthCheckDetailsSuccess("NORMAL", true));
 
-        executorServer[2] = launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskType.CASSANDRA_SERVER_RUN);
+        executorServer[2] = launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
 
         executorTaskRunning(executorServer[2]._1);
 
@@ -1434,11 +1424,11 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         Protos.TaskInfo taskInfo = launchTasks._2.iterator().next();
 
         CassandraFrameworkProtos.TaskDetails taskDetails = taskDetails(taskInfo);
-        assertEquals(CassandraFrameworkProtos.TaskDetails.TaskType.EXECUTOR_METADATA, taskDetails.getTaskType());
+        assertEquals(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.EXECUTOR_METADATA, taskDetails.getType());
         return taskInfo;
     }
 
-    private Protos.TaskInfo launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskType taskType) throws InvalidProtocolBufferException {
+    private Protos.TaskInfo launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType taskType) throws InvalidProtocolBufferException {
         for (Tuple2<Protos.SlaveID, String> slave : slaves) {
             Protos.Offer offer = createOffer(slave);
 
@@ -1456,13 +1446,13 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
             Protos.TaskInfo taskInfo = launchTasks._2.iterator().next();
 
             CassandraFrameworkProtos.TaskDetails taskDetails = taskDetails(taskInfo);
-            assertEquals(taskType, taskDetails.getTaskType());
+            assertEquals(taskType, taskDetails.getType());
             return taskInfo;
         }
         return null;
     }
 
-    private CassandraFrameworkProtos.TaskDetails submitTask(Tuple2<Protos.SlaveID, String> slave, CassandraFrameworkProtos.TaskDetails.TaskType taskType) {
+    private CassandraFrameworkProtos.TaskDetails submitTask(Tuple2<Protos.SlaveID, String> slave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType taskType) {
         Protos.Offer offer = createOffer(slave);
 
         scheduler.resourceOffers(driver, Collections.singletonList(offer));
@@ -1476,7 +1466,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         assertEquals(1, submitTasks.size());
 
         CassandraFrameworkProtos.TaskDetails taskDetails = submitTasks.iterator().next()._2;
-        assertEquals(taskType, taskDetails.getTaskType());
+        assertEquals(taskType, taskDetails.getType());
         return taskDetails;
     }
 
@@ -1494,7 +1484,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
             .contains(Protos.TaskID.newBuilder().setValue(taskID).build());
     }
 
-    private Tuple2<Protos.TaskInfo, CassandraFrameworkProtos.TaskDetails> launchTask(Tuple2<Protos.SlaveID, String> slave, CassandraFrameworkProtos.TaskDetails.TaskType taskType) throws InvalidProtocolBufferException {
+    private Tuple2<Protos.TaskInfo, CassandraFrameworkProtos.TaskDetails> launchTask(Tuple2<Protos.SlaveID, String> slave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType taskType) throws InvalidProtocolBufferException {
         Protos.Offer offer = createOffer(slave);
 
         scheduler.resourceOffers(driver, Collections.singletonList(offer));
@@ -1509,7 +1499,7 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
         Protos.TaskInfo taskInfo = launchTasks._2.iterator().next();
 
         CassandraFrameworkProtos.TaskDetails taskDetails = taskDetails(taskInfo);
-        assertEquals(taskType, taskDetails.getTaskType());
+        assertEquals(taskType, taskDetails.getType());
         return Tuple2.tuple2(taskInfo, taskDetails);
     }
 
@@ -1596,5 +1586,13 @@ public class CassandraSchedulerTest extends AbstractSchedulerTest {
             }
         }
         return null;
+    }
+
+    private static CassandraFrameworkProtos.TaskResources someResources() {
+        return CassandraFrameworkProtos.TaskResources.newBuilder()
+            .setCpuCores(1)
+            .setMemMb(1)
+            .setDiskMb(1)
+            .build();
     }
 }


### PR DESCRIPTION
Add documentation to model.proto,
    add clusterName for framework config,
    extract resources (cpu, mem, disk, ports) to separate message,
    remove unused CleanupScheduledJob + RepairScheduledJob,
    rename URI to FileDownload,
    clarified different TaskType enums used nearby each other

This PR depends on #62 - only commit 5937cb7 is specific to this PR.

I'd really like to remove the datacenter, rack and NodeLocation stuff for now until we have a properly designed solution. WDYT?