### PR TITLE
Update executor memory and disk sizing

### DIFF
--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -758,7 +758,7 @@ public final class CassandraCluster {
             .setExecutorId(executorId)
             .setSource(configuration.frameworkName())
             .setCpuCores(0.1)
-            .setMemMb(256)
+            .setMemMb(384)
             .setDiskMb(256)
             .addAllCommand(command)
             .setTaskEnv(taskEnvFromMap(executorEnv))

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -758,8 +758,8 @@ public final class CassandraCluster {
             .setExecutorId(executorId)
             .setSource(configuration.frameworkName())
             .setCpuCores(0.1)
-            .setMemMb(16)
-            .setDiskMb(16)
+            .setMemMb(256)
+            .setDiskMb(256)
             .addAllCommand(command)
             .setTaskEnv(taskEnvFromMap(executorEnv))
             .addAllResource(newArrayList(
@@ -791,8 +791,8 @@ public final class CassandraCluster {
             .setTaskId(executorId)
             .setExecutorId(executorId)
             .setCpuCores(0.1)
-            .setMemMb(16)
-            .setDiskMb(16)
+            .setMemMb(32)
+            .setDiskMb(0)
             .setTaskDetails(taskDetails)
             .build();
     }


### PR DESCRIPTION
We're setting `-Xms256m -Xmx256m` but weren't claiming the resources so when cgroup isolation is enabled the task is killed with OOM.