### PR TITLE
add missing state change code, add more unit test code

### DIFF
--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/ApiController.java
@@ -1234,7 +1234,7 @@ public final class ApiController {
                 json.writeBooleanField("oldSeedState", cassandraNode.getSeed());
 
                 try {
-                    if (cluster.setNodeSeed(cassandraNode, false)) {
+                    if (cluster.setNodeSeed(cassandraNode, seed)) {
                         json.writeBooleanField("success", true);
                         json.writeBooleanField("seedState", seed);
                     } else {

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterJobs.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterJobs.java
@@ -105,4 +105,24 @@ final class PersistedCassandraClusterJobs extends StatePersistedObject<Cassandra
 
         setValue(clusterJobsBuilder.build());
     }
+
+    public void clearClusterJobCurrentNode(@NotNull String executorId) {
+        CassandraFrameworkProtos.CassandraClusterJobs clusterJobs = get();
+        if (!clusterJobs.hasCurrentClusterJob()) {
+            return;
+        }
+        CassandraFrameworkProtos.ClusterJobStatus current = clusterJobs.getCurrentClusterJob();
+        if (!current.hasCurrentNode()) {
+            return;
+        }
+        CassandraFrameworkProtos.NodeJobStatus currentNode = current.getCurrentNode();
+        if (currentNode.getExecutorId().equals(executorId)) {
+            setCurrentJob(CassandraFrameworkProtos.ClusterJobStatus.newBuilder(current)
+                .clearCurrentNode()
+                .addCompletedNodes(CassandraFrameworkProtos.NodeJobStatus.newBuilder(currentNode)
+                    .setFailed(true)
+                    .setFailureMessage("Task finished without any additional information"))
+                .build());
+        }
+    }
 }

--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterState.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/PersistedCassandraClusterState.java
@@ -116,8 +116,6 @@ final class PersistedCassandraClusterState extends StatePersistedObject<Cassandr
                 nodeList.add(node
                     .setNeedsConfigUpdate(true)
                     .build());
-                nodes(nodeList);
-                return;
             } else {
                 candidate = CassandraFrameworkProtos.CassandraNode.newBuilder(candidate)
                     .setNeedsConfigUpdate(true)

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractCassandraSchedulerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/AbstractCassandraSchedulerTest.java
@@ -1,0 +1,1216 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.mesosphere.mesos.util.ProtoUtils;
+import io.mesosphere.mesos.util.Tuple2;
+import org.apache.mesos.Protos;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+
+public abstract class AbstractCassandraSchedulerTest extends AbstractSchedulerTest {
+    protected CassandraScheduler scheduler;
+    protected MockSchedulerDriver driver;
+
+    protected Protos.TaskInfo[] executorMetadata;
+    protected Tuple2<Protos.TaskInfo, CassandraFrameworkProtos.TaskDetails>[] executorServer;
+
+    protected void partiallyFailingClusterJob(CassandraFrameworkProtos.ClusterJobType clusterJobType) throws InvalidProtocolBufferException {
+        CassandraFrameworkProtos.ClusterJobStatus currentClusterJob = cluster.getCurrentClusterJob();
+        assertNull(currentClusterJob);
+        for (CassandraFrameworkProtos.ClusterJobType jobType : CassandraFrameworkProtos.ClusterJobType.values()) {
+            assertNull(cluster.getCurrentClusterJob(jobType));
+        }
+
+        // simulate API call
+        assertTrue(cluster.startClusterTask(clusterJobType));
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+        for (CassandraFrameworkProtos.ClusterJobType jobType : CassandraFrameworkProtos.ClusterJobType.values()) {
+            if (jobType == clusterJobType) {
+                assertNotNull(cluster.getCurrentClusterJob(jobType));
+            } else {
+                assertNull(cluster.getCurrentClusterJob(jobType));
+                assertFalse(cluster.startClusterTask(jobType));
+            }
+        }
+
+        assertFalse(currentClusterJob.hasCurrentNode());
+        assertEquals(3, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+
+        // launch job on a node
+        Protos.TaskInfo taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        Protos.TaskInfo taskInfo1 = taskInfo;
+        assertNotNull(taskInfo);
+        assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
+
+        // no other slave must produce a task
+        Tuple2<Protos.SlaveID, String> currentSlave = null;
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            if (!slave._1.equals(taskInfo.getSlaveId()))
+                noopOnOffer(slave, 3);
+            else
+                currentSlave = slave;
+        }
+        assertNotNull(currentSlave);
+
+        // check cluster job
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+
+        assertTrue(currentClusterJob.hasCurrentNode());
+        assertEquals(executorIdValue(taskInfo), currentClusterJob.getCurrentNode().getExecutorId());
+        assertEquals(clusterJobType, currentClusterJob.getCurrentNode().getJobType());
+        assertTrue(currentClusterJob.getCurrentNode().hasStartedTimestamp());
+        assertFalse(currentClusterJob.getCurrentNode().hasFinishedTimestamp());
+        assertEquals(2, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+
+        // check job status submit
+
+        CassandraFrameworkProtos.TaskDetails taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS);
+        assertNotNull(taskDetails);
+
+        // simulate job status response
+
+        CassandraFrameworkProtos.NodeJobStatus nodeJobStatus = initialNodeJobStatus(taskInfo, clusterJobType);
+
+        scheduler.frameworkMessage(driver,
+                Protos.ExecutorID.newBuilder().setValue(currentClusterJob.getCurrentNode().getExecutorId()).build(),
+                currentSlave._1,
+                CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+                        .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NODE_JOB_STATUS)
+                        .setNodeJobStatus(nodeJobStatus)
+                        .build().toByteArray());
+
+        // check cluster job after 1st response
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+
+        assertTrue(currentClusterJob.hasCurrentNode());
+        assertEquals(executorIdValue(taskInfo), currentClusterJob.getCurrentNode().getExecutorId());
+        assertEquals(clusterJobType, currentClusterJob.getCurrentNode().getJobType());
+        assertTrue(currentClusterJob.getCurrentNode().hasStartedTimestamp());
+        assertFalse(currentClusterJob.getCurrentNode().hasFinishedTimestamp());
+        assertEquals(2, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+        //
+        // we cannot compare this one:  assertEquals(nodeJobStatus.getStartedTimestamp(), currentClusterJob.getCurrentNode().getStartedTimestamp());
+        assertEquals(Arrays.asList("foo", "bar", "baz"), currentClusterJob.getCurrentNode().getRemainingKeyspacesList());
+        assertEquals(0, currentClusterJob.getCurrentNode().getProcessedKeyspacesCount());
+        assertTrue(currentClusterJob.getCurrentNode().getRunning());
+        assertEquals(taskIdValue(taskInfo), currentClusterJob.getCurrentNode().getTaskId());
+
+        // node has finished ...
+
+        taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS);
+        assertNotNull(taskDetails);
+
+        finishJob(currentClusterJob, taskInfo, currentSlave, nodeJobStatus, clusterJobType);
+        currentClusterJob = cluster.getCurrentClusterJob();
+
+        // cluster job should have no current node yet
+
+        assertNotNull(currentClusterJob);
+        assertEquals(2, currentClusterJob.getRemainingNodesCount());
+        assertEquals(1, currentClusterJob.getCompletedNodesCount());
+        for (CassandraFrameworkProtos.NodeJobStatus jobStatus : currentClusterJob.getCompletedNodesList()) {
+            if (jobStatus.getExecutorId().equals(executorIdValue(taskInfo))) {
+                assertFalse(jobStatus.hasFailed());
+                assertFalse(jobStatus.hasFailureMessage());
+            }
+        }
+        assertFalse(currentClusterJob.hasCurrentNode());
+
+        // 2nd node
+
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        assertNotNull(taskInfo);
+        Protos.TaskInfo taskInfo2 = taskInfo;
+        assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
+        assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
+        assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
+
+        assertNotNull(taskInfo);
+        currentSlave = null;
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            if (!slave._1.equals(taskInfo.getSlaveId()))
+                noopOnOffer(slave, 3);
+            else
+                currentSlave = slave;
+        }
+        assertNotNull(currentSlave);
+        initialNodeJobStatus(taskInfo, clusterJobType);
+
+        // ... just finish 2nd node
+
+        executorTaskError(taskInfo);
+        currentClusterJob = cluster.getCurrentClusterJob();
+
+        assertNotNull(currentClusterJob);
+        assertEquals(1, currentClusterJob.getRemainingNodesCount());
+        assertEquals(2, currentClusterJob.getCompletedNodesCount());
+        for (CassandraFrameworkProtos.NodeJobStatus jobStatus : currentClusterJob.getCompletedNodesList()) {
+            if (jobStatus.getExecutorId().equals(executorIdValue(taskInfo))) {
+                assertTrue(jobStatus.getFailed());
+                assertFalse(jobStatus.getFailureMessage().isEmpty());
+            }
+        }
+        assertFalse(currentClusterJob.hasCurrentNode());
+
+        // 3rd node
+
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        assertNotNull(taskInfo);
+        assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
+        assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
+        assertNotEquals(executorId(taskInfo), executorId(taskInfo2));
+        assertNotEquals(taskInfo.getSlaveId(), taskInfo2.getSlaveId());
+        assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
+
+        assertNotNull(taskInfo);
+        currentSlave = null;
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            if (!slave._1.equals(taskInfo.getSlaveId()))
+                noopOnOffer(slave, 3);
+            else
+                currentSlave = slave;
+        }
+        assertNotNull(currentSlave);
+        nodeJobStatus = initialNodeJobStatus(taskInfo, clusterJobType);
+
+        // ... just finish 3rd node
+
+        finishJob(currentClusterJob, taskInfo, currentSlave, nodeJobStatus, clusterJobType);
+        currentClusterJob = cluster.getCurrentClusterJob();
+
+        // job finished
+
+        assertNull(currentClusterJob);
+        for (CassandraFrameworkProtos.ClusterJobType jobType : CassandraFrameworkProtos.ClusterJobType.values()) {
+            assertNull(cluster.getCurrentClusterJob(jobType));
+        }
+
+        currentClusterJob = cluster.getLastClusterJob(clusterJobType);
+        assertNotNull(currentClusterJob);
+
+        assertFalse(currentClusterJob.hasCurrentNode());
+        assertEquals(0, currentClusterJob.getRemainingNodesCount());
+        assertEquals(3, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertTrue(currentClusterJob.hasFinishedTimestamp());
+
+        // no tasks
+
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            noopOnOffer(slave, activeNodes);
+        }
+    }
+
+    protected void clusterJob(CassandraFrameworkProtos.ClusterJobType clusterJobType) throws InvalidProtocolBufferException {
+        CassandraFrameworkProtos.ClusterJobStatus currentClusterJob = cluster.getCurrentClusterJob();
+        assertNull(currentClusterJob);
+        for (CassandraFrameworkProtos.ClusterJobType jobType : CassandraFrameworkProtos.ClusterJobType.values()) {
+            assertNull(cluster.getCurrentClusterJob(jobType));
+        }
+
+        // simulate API call
+        assertTrue(cluster.startClusterTask(clusterJobType));
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+        for (CassandraFrameworkProtos.ClusterJobType jobType : CassandraFrameworkProtos.ClusterJobType.values()) {
+            if (jobType == clusterJobType) {
+                assertNotNull(cluster.getCurrentClusterJob(jobType));
+            } else {
+                assertNull(cluster.getCurrentClusterJob(jobType));
+                assertFalse(cluster.startClusterTask(jobType));
+            }
+        }
+
+        assertFalse(currentClusterJob.hasCurrentNode());
+        assertEquals(3, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+
+        // launch job on a node
+        Protos.TaskInfo taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        Protos.TaskInfo taskInfo1 = taskInfo;
+        assertNotNull(taskInfo);
+        assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
+
+        // no other slave must produce a task
+        Tuple2<Protos.SlaveID, String> currentSlave = null;
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            if (!slave._1.equals(taskInfo.getSlaveId()))
+                noopOnOffer(slave, 3);
+            else
+                currentSlave = slave;
+        }
+        assertNotNull(currentSlave);
+
+        // check cluster job
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+
+        assertTrue(currentClusterJob.hasCurrentNode());
+        assertEquals(executorIdValue(taskInfo), currentClusterJob.getCurrentNode().getExecutorId());
+        assertEquals(clusterJobType, currentClusterJob.getCurrentNode().getJobType());
+        assertTrue(currentClusterJob.getCurrentNode().hasStartedTimestamp());
+        assertFalse(currentClusterJob.getCurrentNode().hasFinishedTimestamp());
+        assertEquals(2, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+
+        // check job status submit
+
+        CassandraFrameworkProtos.TaskDetails taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS);
+        assertNotNull(taskDetails);
+
+        // simulate job status response
+
+        CassandraFrameworkProtos.NodeJobStatus nodeJobStatus = initialNodeJobStatus(taskInfo, clusterJobType);
+
+        scheduler.frameworkMessage(driver,
+            Protos.ExecutorID.newBuilder().setValue(currentClusterJob.getCurrentNode().getExecutorId()).build(),
+            currentSlave._1,
+            CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+                .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NODE_JOB_STATUS)
+                .setNodeJobStatus(nodeJobStatus)
+                .build().toByteArray());
+
+        // check cluster job after 1st response
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+
+        assertTrue(currentClusterJob.hasCurrentNode());
+        assertEquals(executorIdValue(taskInfo), currentClusterJob.getCurrentNode().getExecutorId());
+        assertEquals(clusterJobType, currentClusterJob.getCurrentNode().getJobType());
+        assertTrue(currentClusterJob.getCurrentNode().hasStartedTimestamp());
+        assertFalse(currentClusterJob.getCurrentNode().hasFinishedTimestamp());
+        assertEquals(2, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+        //
+        // we cannot compare this one:  assertEquals(nodeJobStatus.getStartedTimestamp(), currentClusterJob.getCurrentNode().getStartedTimestamp());
+        assertEquals(Arrays.asList("foo", "bar", "baz"), currentClusterJob.getCurrentNode().getRemainingKeyspacesList());
+        assertEquals(0, currentClusterJob.getCurrentNode().getProcessedKeyspacesCount());
+        assertTrue(currentClusterJob.getCurrentNode().getRunning());
+        assertEquals(taskIdValue(taskInfo), currentClusterJob.getCurrentNode().getTaskId());
+
+        // node has finished ...
+
+        taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS);
+        assertNotNull(taskDetails);
+
+        finishJob(currentClusterJob, taskInfo, currentSlave, nodeJobStatus, clusterJobType);
+        currentClusterJob = cluster.getCurrentClusterJob();
+
+        // cluster job should have no current node yet
+
+        assertNotNull(currentClusterJob);
+        assertEquals(2, currentClusterJob.getRemainingNodesCount());
+        assertEquals(1, currentClusterJob.getCompletedNodesCount());
+        assertFalse(currentClusterJob.hasCurrentNode());
+
+        // 2nd node
+
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        assertNotNull(taskInfo);
+        Protos.TaskInfo taskInfo2 = taskInfo;
+        assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
+        assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
+        assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
+
+        assertNotNull(taskInfo);
+        currentSlave = null;
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            if (!slave._1.equals(taskInfo.getSlaveId()))
+                noopOnOffer(slave, 3);
+            else
+                currentSlave = slave;
+        }
+        assertNotNull(currentSlave);
+        nodeJobStatus = initialNodeJobStatus(taskInfo, clusterJobType);
+
+        // ... just finish 2nd node
+
+        finishJob(currentClusterJob, taskInfo, currentSlave, nodeJobStatus, clusterJobType);
+        currentClusterJob = cluster.getCurrentClusterJob();
+
+        assertNotNull(currentClusterJob);
+        assertEquals(1, currentClusterJob.getRemainingNodesCount());
+        assertEquals(2, currentClusterJob.getCompletedNodesCount());
+        assertFalse(currentClusterJob.hasCurrentNode());
+
+        // 3rd node
+
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        assertNotNull(taskInfo);
+        assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
+        assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
+        assertNotEquals(executorId(taskInfo), executorId(taskInfo2));
+        assertNotEquals(taskInfo.getSlaveId(), taskInfo2.getSlaveId());
+        assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
+
+        assertNotNull(taskInfo);
+        currentSlave = null;
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            if (!slave._1.equals(taskInfo.getSlaveId()))
+                noopOnOffer(slave, 3);
+            else
+                currentSlave = slave;
+        }
+        assertNotNull(currentSlave);
+        nodeJobStatus = initialNodeJobStatus(taskInfo, clusterJobType);
+
+        // ... just finish 3rd node
+
+        finishJob(currentClusterJob, taskInfo, currentSlave, nodeJobStatus, clusterJobType);
+        currentClusterJob = cluster.getCurrentClusterJob();
+
+        // job finished
+
+        assertNull(currentClusterJob);
+
+        currentClusterJob = cluster.getLastClusterJob(clusterJobType);
+        assertNotNull(currentClusterJob);
+
+        assertFalse(currentClusterJob.hasCurrentNode());
+        assertEquals(0, currentClusterJob.getRemainingNodesCount());
+        assertEquals(3, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertTrue(currentClusterJob.hasFinishedTimestamp());
+        for (CassandraFrameworkProtos.NodeJobStatus jobStatus : currentClusterJob.getCompletedNodesList()) {
+            assertEquals(clusterJobType, jobStatus.getJobType());
+            assertEquals(3, jobStatus.getProcessedKeyspacesCount());
+            assertEquals(0, jobStatus.getRemainingKeyspacesCount());
+            assertFalse(jobStatus.getRunning());
+        }
+
+        // no tasks
+
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            noopOnOffer(slave, activeNodes);
+        }
+    }
+
+    protected void clusterJobFailingNode(CassandraFrameworkProtos.ClusterJobType clusterJobType) throws InvalidProtocolBufferException {
+        CassandraFrameworkProtos.ClusterJobStatus currentClusterJob = cluster.getCurrentClusterJob();
+        assertNull(currentClusterJob);
+        for (CassandraFrameworkProtos.ClusterJobType jobType : CassandraFrameworkProtos.ClusterJobType.values()) {
+            assertNull(cluster.getCurrentClusterJob(jobType));
+        }
+
+        // simulate API call
+        assertTrue(cluster.startClusterTask(clusterJobType));
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+        for (CassandraFrameworkProtos.ClusterJobType jobType : CassandraFrameworkProtos.ClusterJobType.values()) {
+            if (jobType == clusterJobType) {
+                assertNotNull(cluster.getCurrentClusterJob(jobType));
+            } else {
+                assertNull(cluster.getCurrentClusterJob(jobType));
+                assertFalse(cluster.startClusterTask(jobType));
+            }
+        }
+
+        assertFalse(currentClusterJob.hasCurrentNode());
+        assertEquals(3, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+
+        // launch job on a node
+        Protos.TaskInfo taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        Protos.TaskInfo taskInfo1 = taskInfo;
+        assertNotNull(taskInfo);
+        assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
+
+        // no other slave must produce a task
+        Tuple2<Protos.SlaveID, String> currentSlave = null;
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            if (!slave._1.equals(taskInfo.getSlaveId()))
+                noopOnOffer(slave, 3);
+            else
+                currentSlave = slave;
+        }
+        assertNotNull(currentSlave);
+
+        // check cluster job
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+
+        assertTrue(currentClusterJob.hasCurrentNode());
+        assertEquals(executorIdValue(taskInfo), currentClusterJob.getCurrentNode().getExecutorId());
+        assertEquals(clusterJobType, currentClusterJob.getCurrentNode().getJobType());
+        assertTrue(currentClusterJob.getCurrentNode().hasStartedTimestamp());
+        assertFalse(currentClusterJob.getCurrentNode().hasFinishedTimestamp());
+        assertEquals(2, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+
+        // check job status submit
+
+        CassandraFrameworkProtos.TaskDetails taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS);
+        assertNotNull(taskDetails);
+
+        // simulate job status response
+
+        CassandraFrameworkProtos.NodeJobStatus nodeJobStatus = initialNodeJobStatus(taskInfo, clusterJobType);
+
+        scheduler.frameworkMessage(driver,
+            Protos.ExecutorID.newBuilder().setValue(currentClusterJob.getCurrentNode().getExecutorId()).build(),
+            currentSlave._1,
+            CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+                .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NODE_JOB_STATUS)
+                .setNodeJobStatus(nodeJobStatus)
+                .build().toByteArray());
+
+        // check cluster job after 1st response
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+
+        assertTrue(currentClusterJob.hasCurrentNode());
+        assertEquals(executorIdValue(taskInfo), currentClusterJob.getCurrentNode().getExecutorId());
+        assertEquals(clusterJobType, currentClusterJob.getCurrentNode().getJobType());
+        assertTrue(currentClusterJob.getCurrentNode().hasStartedTimestamp());
+        assertFalse(currentClusterJob.getCurrentNode().hasFinishedTimestamp());
+        assertEquals(2, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+        //
+        // we cannot compare this one:  assertEquals(nodeJobStatus.getStartedTimestamp(), currentClusterJob.getCurrentNode().getStartedTimestamp());
+        assertEquals(Arrays.asList("foo", "bar", "baz"), currentClusterJob.getCurrentNode().getRemainingKeyspacesList());
+        assertEquals(0, currentClusterJob.getCurrentNode().getProcessedKeyspacesCount());
+        assertTrue(currentClusterJob.getCurrentNode().getRunning());
+        assertEquals(taskIdValue(taskInfo), currentClusterJob.getCurrentNode().getTaskId());
+
+        // node 1 task failed
+        CassandraFrameworkProtos.NodeJobStatus node = currentClusterJob.getCurrentNode();
+        Tuple2<Protos.SlaveID, String> slave = slaveForNode(node);
+
+        scheduler.statusUpdate(driver, Protos.TaskStatus.newBuilder()
+            .setTimestamp(1)
+            .setTaskId(Protos.TaskID.newBuilder().setValue("TASK"))
+            .setSlaveId(slave._1)
+            .setMessage("foo bar")
+            .setExecutorId(Protos.ExecutorID.newBuilder().setValue(node.getExecutorId()))
+            .setHealthy(true)
+            .setSource(Protos.TaskStatus.Source.SOURCE_SLAVE)
+            .setReason(Protos.TaskStatus.Reason.REASON_EXECUTOR_TERMINATED)
+            .setState(Protos.TaskState.TASK_FINISHED)
+            .build());
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+        assertFalse(currentClusterJob.hasCurrentNode());
+
+        launchTask(slave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.EXECUTOR_METADATA);
+
+        // 2nd node
+
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        assertNotNull(taskInfo);
+        Protos.TaskInfo taskInfo2 = taskInfo;
+        assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
+        assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
+        assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
+
+        assertNotNull(taskInfo);
+        currentSlave = null;
+        for (Tuple2<Protos.SlaveID, String> s : slaves) {
+            if (!s._1.equals(taskInfo.getSlaveId()))
+                noopOnOffer(s, 3);
+            else
+                currentSlave = s;
+        }
+        assertNotNull(currentSlave);
+        nodeJobStatus = initialNodeJobStatus(taskInfo, clusterJobType);
+
+        scheduler.frameworkMessage(driver,
+            Protos.ExecutorID.newBuilder().setValue(currentClusterJob.getCurrentNode().getExecutorId()).build(),
+            currentSlave._1,
+            CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+                .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NODE_JOB_STATUS)
+                .setNodeJobStatus(nodeJobStatus)
+                .build().toByteArray());
+
+        // slave for node 2 lost
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        node = currentClusterJob.getCurrentNode();
+        slave = slaveForNode(node);
+        scheduler.executorLost(driver, Protos.ExecutorID.newBuilder().setValue(node.getExecutorId()).build(), slave._1, 42);
+
+        // ... just finish 2nd node
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+        assertFalse(currentClusterJob.hasCurrentNode());
+
+        launchTask(slave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.EXECUTOR_METADATA);
+
+        assertNotNull(currentClusterJob);
+        assertEquals(1, currentClusterJob.getRemainingNodesCount());
+        assertEquals(2, currentClusterJob.getCompletedNodesCount());
+        assertFalse(currentClusterJob.hasCurrentNode());
+
+        // 3rd node
+
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        assertNotNull(taskInfo);
+        assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
+        assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
+        assertNotEquals(executorId(taskInfo), executorId(taskInfo2));
+        assertNotEquals(taskInfo.getSlaveId(), taskInfo2.getSlaveId());
+        assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
+
+        assertNotNull(taskInfo);
+        currentSlave = null;
+        for (Tuple2<Protos.SlaveID, String> s : slaves) {
+            if (!s._1.equals(taskInfo.getSlaveId()))
+                noopOnOffer(s, 3);
+            else
+                currentSlave = s;
+        }
+        assertNotNull(currentSlave);
+        nodeJobStatus = initialNodeJobStatus(taskInfo, clusterJobType);
+
+        // ... just finish 3rd node
+
+        finishJob(currentClusterJob, taskInfo, currentSlave, nodeJobStatus, clusterJobType);
+        currentClusterJob = cluster.getCurrentClusterJob();
+
+        // job finished
+
+        assertNull(currentClusterJob);
+
+        currentClusterJob = cluster.getLastClusterJob(clusterJobType);
+        assertNotNull(currentClusterJob);
+
+        assertFalse(currentClusterJob.hasCurrentNode());
+        assertEquals(0, currentClusterJob.getRemainingNodesCount());
+        assertEquals(3, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertTrue(currentClusterJob.hasFinishedTimestamp());
+
+        // no tasks
+
+        for (Tuple2<Protos.SlaveID, String> s : slaves) {
+            noopOnOffer(s, activeNodes);
+        }
+    }
+
+    protected Tuple2<Protos.SlaveID, String> slaveForNode(CassandraFrameworkProtos.NodeJobStatus node) {
+        for (int i = 0; i < executorMetadata.length; i++) {
+            if (node.getExecutorId().equals(executorMetadata[i].getExecutorOrBuilder().getExecutorId().getValue())) {
+                return slaves[i];
+            }
+        }
+        return null;
+    }
+
+    protected void clusterJobAbort(CassandraFrameworkProtos.ClusterJobType clusterJobType) throws InvalidProtocolBufferException {
+        CassandraFrameworkProtos.ClusterJobStatus currentClusterJob = cluster.getCurrentClusterJob();
+        assertNull(currentClusterJob);
+        for (CassandraFrameworkProtos.ClusterJobType jobType : CassandraFrameworkProtos.ClusterJobType.values()) {
+            assertNull(cluster.getCurrentClusterJob(jobType));
+        }
+
+        // simulate API call
+        assertTrue(cluster.startClusterTask(clusterJobType));
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+        for (CassandraFrameworkProtos.ClusterJobType jobType : CassandraFrameworkProtos.ClusterJobType.values()) {
+            if (jobType == clusterJobType) {
+                assertNotNull(cluster.getCurrentClusterJob(jobType));
+            } else {
+                assertNull(cluster.getCurrentClusterJob(jobType));
+                assertFalse(cluster.startClusterTask(jobType));
+            }
+        }
+
+        assertFalse(currentClusterJob.hasCurrentNode());
+        assertEquals(3, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+
+        // launch job on a node
+        Protos.TaskInfo taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        Protos.TaskInfo taskInfo1 = taskInfo;
+        assertNotNull(taskInfo);
+        assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
+
+        // no other slave must produce a task
+        Tuple2<Protos.SlaveID, String> currentSlave = null;
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            if (!slave._1.equals(taskInfo.getSlaveId()))
+                noopOnOffer(slave, 3);
+            else
+                currentSlave = slave;
+        }
+        assertNotNull(currentSlave);
+
+        // check cluster job
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+
+        assertTrue(currentClusterJob.hasCurrentNode());
+        assertEquals(executorIdValue(taskInfo), currentClusterJob.getCurrentNode().getExecutorId());
+        assertEquals(clusterJobType, currentClusterJob.getCurrentNode().getJobType());
+        assertTrue(currentClusterJob.getCurrentNode().hasStartedTimestamp());
+        assertFalse(currentClusterJob.getCurrentNode().hasFinishedTimestamp());
+        assertEquals(2, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+
+        // check job status submit
+
+        CassandraFrameworkProtos.TaskDetails taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS);
+        assertNotNull(taskDetails);
+
+        // simulate job status response
+
+        CassandraFrameworkProtos.NodeJobStatus nodeJobStatus = initialNodeJobStatus(taskInfo, clusterJobType);
+
+        scheduler.frameworkMessage(driver,
+            Protos.ExecutorID.newBuilder().setValue(currentClusterJob.getCurrentNode().getExecutorId()).build(),
+            currentSlave._1,
+            CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+                .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NODE_JOB_STATUS)
+                .setNodeJobStatus(nodeJobStatus)
+                .build().toByteArray());
+
+        // check cluster job after 1st response
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+
+        assertTrue(currentClusterJob.hasCurrentNode());
+        assertEquals(executorIdValue(taskInfo), currentClusterJob.getCurrentNode().getExecutorId());
+        assertEquals(clusterJobType, currentClusterJob.getCurrentNode().getJobType());
+        assertTrue(currentClusterJob.getCurrentNode().hasStartedTimestamp());
+        assertFalse(currentClusterJob.getCurrentNode().hasFinishedTimestamp());
+        assertEquals(2, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+        //
+        // we cannot compare this one:  assertEquals(nodeJobStatus.getStartedTimestamp(), currentClusterJob.getCurrentNode().getStartedTimestamp());
+        assertEquals(Arrays.asList("foo", "bar", "baz"), currentClusterJob.getCurrentNode().getRemainingKeyspacesList());
+        assertEquals(0, currentClusterJob.getCurrentNode().getProcessedKeyspacesCount());
+        assertTrue(currentClusterJob.getCurrentNode().getRunning());
+        assertEquals(taskIdValue(taskInfo), currentClusterJob.getCurrentNode().getTaskId());
+
+        // node has finished ...
+
+        taskDetails = submitTask(currentSlave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB_STATUS);
+        assertNotNull(taskDetails);
+
+        finishJob(currentClusterJob, taskInfo, currentSlave, nodeJobStatus, clusterJobType);
+        currentClusterJob = cluster.getCurrentClusterJob();
+
+        // cluster job should have no current node yet
+
+        assertNotNull(currentClusterJob);
+        assertEquals(2, currentClusterJob.getRemainingNodesCount());
+        assertEquals(1, currentClusterJob.getCompletedNodesCount());
+        assertFalse(currentClusterJob.hasCurrentNode());
+
+        // 2nd node
+
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        assertNotNull(taskInfo);
+        assertNotEquals(executorId(taskInfo), executorId(taskInfo1));
+        assertNotEquals(taskInfo.getSlaveId(), taskInfo1.getSlaveId());
+        assertEquals(executorIdValue(taskInfo) + '.' + clusterJobType.name(), taskIdValue(taskInfo));
+
+        assertNotNull(taskInfo);
+        currentSlave = null;
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            if (!slave._1.equals(taskInfo.getSlaveId()))
+                noopOnOffer(slave, 3);
+            else
+                currentSlave = slave;
+        }
+        assertNotNull(currentSlave);
+        nodeJobStatus = initialNodeJobStatus(taskInfo, clusterJobType);
+
+        // ABORT THE CLUSTER JOB
+
+        cluster.abortClusterJob(clusterJobType);
+
+        // ... just finish 2nd node
+
+        finishJob(currentClusterJob, taskInfo, currentSlave, nodeJobStatus, clusterJobType);
+        currentClusterJob = cluster.getCurrentClusterJob();
+
+        assertNotNull(currentClusterJob);
+        assertEquals(1, currentClusterJob.getRemainingNodesCount());
+        assertEquals(2, currentClusterJob.getCompletedNodesCount());
+        assertFalse(currentClusterJob.hasCurrentNode());
+
+        // 3rd node
+
+        taskInfo = launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.NODE_JOB);
+        assertNull(taskInfo);
+
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            noopOnOffer(slave, 3);
+        }
+
+        // job finished
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNull(currentClusterJob);
+
+        currentClusterJob = cluster.getLastClusterJob(clusterJobType);
+        assertNotNull(currentClusterJob);
+
+        assertFalse(currentClusterJob.hasCurrentNode());
+        assertEquals(0, currentClusterJob.getRemainingNodesCount());
+        assertEquals(3, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertTrue(currentClusterJob.hasFinishedTimestamp());
+        for (CassandraFrameworkProtos.NodeJobStatus jobStatus : currentClusterJob.getCompletedNodesList()) {
+            assertEquals(clusterJobType, jobStatus.getJobType());
+            assertEquals(3, jobStatus.getProcessedKeyspacesCount());
+            assertEquals(0, jobStatus.getRemainingKeyspacesCount());
+            assertFalse(jobStatus.getRunning());
+        }
+
+        // no tasks
+
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            noopOnOffer(slave, activeNodes);
+        }
+    }
+
+    protected static CassandraFrameworkProtos.NodeJobStatus initialNodeJobStatus(Protos.TaskInfo taskInfo, CassandraFrameworkProtos.ClusterJobType clusterJobType) {
+        return CassandraFrameworkProtos.NodeJobStatus.newBuilder()
+                .setJobType(clusterJobType)
+                .setExecutorId(executorIdValue(taskInfo))
+                .setTaskId(taskIdValue(taskInfo))
+                .setRunning(true)
+                .setStartedTimestamp(System.currentTimeMillis())
+                .addAllRemainingKeyspaces(Arrays.asList("foo", "bar", "baz"))
+                .build();
+    }
+
+    protected void finishJob(CassandraFrameworkProtos.ClusterJobStatus currentClusterJob, Protos.TaskInfo taskInfo, Tuple2<Protos.SlaveID, String> currentSlave, CassandraFrameworkProtos.NodeJobStatus nodeJobStatus, CassandraFrameworkProtos.ClusterJobType clusterJobType) {
+        nodeJobStatus = CassandraFrameworkProtos.NodeJobStatus.newBuilder()
+                .setJobType(clusterJobType)
+                .setExecutorId(executorIdValue(taskInfo))
+                .setTaskId(taskIdValue(taskInfo))
+                .setRunning(false)
+                .setStartedTimestamp(nodeJobStatus.getStartedTimestamp())
+                .setFinishedTimestamp(System.currentTimeMillis())
+                .addAllProcessedKeyspaces(Arrays.asList(
+                        CassandraFrameworkProtos.ClusterJobKeyspaceStatus.newBuilder()
+                                .setDuration(1)
+                                .setKeyspace("foo")
+                                .setStatus("FOO")
+                                .build(),
+                        CassandraFrameworkProtos.ClusterJobKeyspaceStatus.newBuilder()
+                                .setDuration(1)
+                                .setKeyspace("bar")
+                                .setStatus("BAR")
+                                .build(),
+                        CassandraFrameworkProtos.ClusterJobKeyspaceStatus.newBuilder()
+                                .setDuration(1)
+                                .setKeyspace("baz")
+                                .setStatus("BAZ")
+                                .build()
+                ))
+            .build();
+
+        executorTaskFinished(taskInfo, CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+            .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NODE_JOB_STATUS)
+            .setNodeJobStatus(nodeJobStatus)
+            .build());
+        scheduler.frameworkMessage(driver,
+            Protos.ExecutorID.newBuilder().setValue(currentClusterJob.getCurrentNode().getExecutorId()).build(),
+            currentSlave._1,
+            CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+                .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NODE_JOB_STATUS)
+                .setNodeJobStatus(nodeJobStatus)
+                        .build().toByteArray());
+    }
+
+    protected void addFourthNode() throws InvalidProtocolBufferException {
+        startFourthNode();
+
+        fourthNodeRunning();
+    }
+
+    protected void fourthNodeRunning() {
+        executorTaskRunning(executorMetadata[3]);
+        executorTaskRunning(executorServer[3]._1);
+        sendHealthCheckResult(executorMetadata[3], healthCheckDetailsSuccess("NORMAL", true));
+    }
+
+    protected void startFourthNode() throws InvalidProtocolBufferException {
+        executorMetadata[3] = launchExecutor(slaves[3], 4);
+        executorTaskRunning(executorMetadata[3]);
+
+        executorServer[3] = launchTask(slaves[3], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+    }
+
+    protected Protos.TaskInfo[] threeNodeCluster() throws InvalidProtocolBufferException {
+        cleanState();
+
+        activeNodes = 3;
+
+        // rollout slaves
+        executorMetadata = new Protos.TaskInfo[slaves.length];
+        executorMetadata[0] = launchExecutor(slaves[0], 1);
+        executorMetadata[1] = launchExecutor(slaves[1], 2);
+        executorMetadata[2] = launchExecutor(slaves[2], 3);
+
+        return threeNodeClusterPost();
+    }
+
+    protected Protos.TaskInfo[] threeNodeClusterPost() throws InvalidProtocolBufferException {
+        executorTaskRunning(executorMetadata[0]);
+        executorTaskRunning(executorMetadata[1]);
+        executorTaskRunning(executorMetadata[2]);
+
+        // launch servers
+
+        //noinspection unchecked
+        executorServer = new Tuple2[slaves.length];
+
+        executorServer[0] = launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+        executorServer[1] = launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+
+        executorTaskRunning(executorServer[0]._1);
+        executorTaskRunning(executorServer[1]._1);
+
+        sendHealthCheckResult(executorMetadata[0], healthCheckDetailsSuccess("NORMAL", true));
+        sendHealthCheckResult(executorMetadata[1], healthCheckDetailsSuccess("NORMAL", true));
+
+        executorServer[2] = launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+
+        executorTaskRunning(executorServer[2]._1);
+
+        sendHealthCheckResult(executorMetadata[2], healthCheckDetailsSuccess("NORMAL", true));
+        return executorMetadata;
+    }
+
+    protected void executorTaskError(Protos.TaskInfo taskInfo) {
+        scheduler.statusUpdate(driver, Protos.TaskStatus.newBuilder()
+            .setExecutorId(executorId(taskInfo))
+            .setHealthy(true)
+            .setSlaveId(taskInfo.getSlaveId())
+            .setSource(Protos.TaskStatus.Source.SOURCE_EXECUTOR)
+            .setTaskId(taskInfo.getTaskId())
+            .setTimestamp(System.currentTimeMillis())
+            .setState(Protos.TaskState.TASK_ERROR)
+                .build());
+    }
+
+    protected void executorTaskRunning(Protos.TaskInfo taskInfo) {
+        scheduler.statusUpdate(driver, Protos.TaskStatus.newBuilder()
+            .setExecutorId(executorId(taskInfo))
+            .setHealthy(true)
+            .setSlaveId(taskInfo.getSlaveId())
+            .setSource(Protos.TaskStatus.Source.SOURCE_EXECUTOR)
+            .setTaskId(taskInfo.getTaskId())
+            .setTimestamp(System.currentTimeMillis())
+            .setState(Protos.TaskState.TASK_RUNNING)
+            .setData(CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+                .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.EXECUTOR_METADATA)
+                .setExecutorMetadata(CassandraFrameworkProtos.ExecutorMetadata.newBuilder()
+                    .setExecutorId(executorIdValue(taskInfo))
+                    .setIp("NO_IP!!!")
+                    .setWorkdir("/foo/bar/baz"))
+                .build().toByteString())
+            .build());
+    }
+
+    protected void executorTaskFinished(Protos.TaskInfo taskInfo, CassandraFrameworkProtos.SlaveStatusDetails slaveStatusDetails) {
+        scheduler.statusUpdate(driver, Protos.TaskStatus.newBuilder()
+            .setExecutorId(executorId(taskInfo))
+            .setHealthy(true)
+            .setSlaveId(taskInfo.getSlaveId())
+            .setSource(Protos.TaskStatus.Source.SOURCE_EXECUTOR)
+            .setTaskId(taskInfo.getTaskId())
+            .setTimestamp(System.currentTimeMillis())
+            .setState(Protos.TaskState.TASK_FINISHED)
+            .setData(slaveStatusDetails.toByteString())
+            .build());
+    }
+
+    protected void sendHealthCheckResult(Protos.TaskInfo taskInfo, CassandraFrameworkProtos.HealthCheckDetails healthCheckDetails) {
+        scheduler.frameworkMessage(driver, executorId(taskInfo), taskInfo.getSlaveId(),
+            CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+                .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.HEALTH_CHECK_DETAILS)
+                .setHealthCheckDetails(healthCheckDetails).build().toByteArray());
+    }
+
+    protected Protos.TaskInfo launchExecutor(Tuple2<Protos.SlaveID, String> slave, int nodeCount) throws InvalidProtocolBufferException {
+        Protos.Offer offer = createOffer(slave);
+
+        scheduler.resourceOffers(driver, Collections.singletonList(offer));
+
+        Tuple2<Collection<Protos.OfferID>, Collection<Protos.TaskInfo>> launchTasks = driver.launchTasks();
+        assertTrue(driver.declinedOffers().isEmpty());
+        assertTrue(driver.submitTasks().isEmpty());
+        assertTrue(driver.killTasks().isEmpty());
+
+        assertEquals(nodeCount, cluster.getClusterState().get().getNodesCount());
+        assertEquals(1, launchTasks._2.size());
+
+        Protos.TaskInfo taskInfo = launchTasks._2.iterator().next();
+
+        CassandraFrameworkProtos.TaskDetails taskDetails = taskDetails(taskInfo);
+        assertEquals(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.EXECUTOR_METADATA, taskDetails.getType());
+        return taskInfo;
+    }
+
+    protected Protos.TaskInfo launchTaskOnAny(CassandraFrameworkProtos.TaskDetails.TaskDetailsType taskType) throws InvalidProtocolBufferException {
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            Protos.Offer offer = createOffer(slave);
+
+            scheduler.resourceOffers(driver, Collections.singletonList(offer));
+
+            Tuple2<Collection<Protos.OfferID>, Collection<Protos.TaskInfo>> launchTasks = driver.launchTasks();
+            if (!driver.declinedOffers().isEmpty())
+                continue;
+
+            assertEquals(1, launchTasks._2.size());
+            assertTrue(driver.submitTasks().isEmpty());
+            assertTrue(driver.killTasks().isEmpty());
+
+            Protos.TaskInfo taskInfo = launchTasks._2.iterator().next();
+
+            CassandraFrameworkProtos.TaskDetails taskDetails = taskDetails(taskInfo);
+            assertEquals(taskType, taskDetails.getType());
+            return taskInfo;
+        }
+        return null;
+    }
+
+    protected CassandraFrameworkProtos.TaskDetails submitTask(Tuple2<Protos.SlaveID, String> slave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType taskType) {
+        Protos.Offer offer = createOffer(slave);
+
+        scheduler.resourceOffers(driver, Collections.singletonList(offer));
+
+        assertFalse(driver.declinedOffers().isEmpty());
+        Tuple2<Collection<Protos.OfferID>, Collection<Protos.TaskInfo>> launchTasks = driver.launchTasks();
+        assertTrue(launchTasks._2.isEmpty());
+        Collection<Tuple2<Protos.ExecutorID, CassandraFrameworkProtos.TaskDetails>> submitTasks = driver.submitTasks();
+        assertTrue(driver.killTasks().isEmpty());
+
+        assertEquals(1, submitTasks.size());
+
+        CassandraFrameworkProtos.TaskDetails taskDetails = submitTasks.iterator().next()._2;
+        assertEquals(taskType, taskDetails.getType());
+        return taskDetails;
+    }
+
+    protected void killTask(Tuple2<Protos.SlaveID, String> slave, String taskID) {
+        Protos.Offer offer = createOffer(slave);
+
+        scheduler.resourceOffers(driver, Collections.singletonList(offer));
+
+        assertThat(driver.declinedOffers())
+            .hasSize(1);
+        assertTrue(driver.launchTasks()._2.isEmpty());
+        assertTrue(driver.submitTasks().isEmpty());
+        assertThat(driver.killTasks())
+            .hasSize(1)
+            .contains(Protos.TaskID.newBuilder().setValue(taskID).build());
+    }
+
+    protected Tuple2<Protos.TaskInfo, CassandraFrameworkProtos.TaskDetails> launchTask(Tuple2<Protos.SlaveID, String> slave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType taskType) throws InvalidProtocolBufferException {
+        Protos.Offer offer = createOffer(slave);
+
+        scheduler.resourceOffers(driver, Collections.singletonList(offer));
+
+        assertTrue(driver.declinedOffers().isEmpty());
+        Tuple2<Collection<Protos.OfferID>, Collection<Protos.TaskInfo>> launchTasks = driver.launchTasks();
+        assertTrue(driver.submitTasks().isEmpty());
+        assertTrue(driver.killTasks().isEmpty());
+
+        assertEquals(1, launchTasks._2.size());
+
+        Protos.TaskInfo taskInfo = launchTasks._2.iterator().next();
+
+        CassandraFrameworkProtos.TaskDetails taskDetails = taskDetails(taskInfo);
+        assertEquals(taskType, taskDetails.getType());
+        return Tuple2.tuple2(taskInfo, taskDetails);
+    }
+
+    protected static CassandraFrameworkProtos.TaskDetails taskDetails(Protos.TaskInfo data) throws InvalidProtocolBufferException {
+        return CassandraFrameworkProtos.TaskDetails.parseFrom(data.getData());
+    }
+
+    protected void noopOnOffer(Tuple2<Protos.SlaveID, String> slave, int nodeCount) {
+        noopOnOffer(slave, nodeCount, false);
+    }
+
+    protected void noopOnOffer(Tuple2<Protos.SlaveID, String> slave, int nodeCount, boolean ignoreKills) {
+        Protos.Offer offer = createOffer(slave);
+
+        scheduler.resourceOffers(driver, Collections.singletonList(offer));
+
+        Tuple2<Collection<Protos.OfferID>, Collection<Protos.TaskInfo>> launchTasks = driver.launchTasks();
+        assertTrue(ProtoUtils.protoToString(driver.submitTasks()), driver.submitTasks().isEmpty());
+        boolean noKills = driver.killTasks().isEmpty();
+        if (!ignoreKills) {
+            assertTrue(noKills);
+        }
+        List<Protos.OfferID> decl = driver.declinedOffers();
+        assertThat(decl)
+            .hasSize(1)
+            .contains(offer.getId());
+
+        assertEquals(nodeCount, cluster.getClusterState().get().getNodesCount());
+        assertEquals(0, launchTasks._2.size());
+    }
+
+    protected void noopOnOfferAll() {
+        for (Tuple2<Protos.SlaveID, String> slave : slaves) {
+            noopOnOffer(slave, activeNodes);
+        }
+    }
+
+    protected void cleanState() {
+        super.cleanState();
+
+        scheduler = new CassandraScheduler(configuration, cluster);
+
+        driver = new MockSchedulerDriver(scheduler);
+    }
+
+    protected static String executorIdValue(Protos.TaskInfo executorMetadata) {
+        return executorId(executorMetadata).getValue();
+    }
+
+    protected static String taskIdValue(Protos.TaskInfo taskInfo) {
+        return taskInfo.getTaskId().getValue();
+    }
+
+    protected static Protos.ExecutorID executorId(Protos.TaskInfo taskInfo) {
+        return taskInfo.getExecutor().getExecutorId();
+    }
+
+    protected CassandraFrameworkProtos.HealthCheckDetails lastHealthCheckDetails(Protos.TaskInfo executorMetadata) {
+        return cluster.lastHealthCheck(executorIdValue(executorMetadata)).getDetails();
+    }
+
+    protected Tuple2<Protos.SlaveID, String> slaveForExecutor(String executorId) {
+        for (int i = 0; i < executorMetadata.length; i++) {
+            if (executorMetadata[i] != null && executorMetadata[i].getExecutor().getExecutorId().getValue().equals(executorId)) {
+                return slaves[i];
+            }
+        }
+        return null;
+    }
+
+    protected Protos.TaskInfo execForExecutor(String executorId) {
+        for (Protos.TaskInfo execMetadata : executorMetadata) {
+            if (execMetadata != null && execMetadata.getExecutor().getExecutorId().getValue().equals(executorId)) {
+                return execMetadata;
+            }
+        }
+        return null;
+    }
+
+    protected Tuple2<Protos.TaskInfo, CassandraFrameworkProtos.TaskDetails> serverTaskForExecutor(String executorId) {
+        for (Tuple2<Protos.TaskInfo, CassandraFrameworkProtos.TaskDetails> serverInfo : executorServer) {
+            if (serverInfo != null && serverInfo._1.getExecutor().getExecutorId().getValue().equals(executorId)) {
+                return serverInfo;
+            }
+        }
+        return null;
+    }
+
+    protected static CassandraFrameworkProtos.TaskResources someResources() {
+        return CassandraFrameworkProtos.TaskResources.newBuilder()
+            .setCpuCores(1)
+            .setMemMb(1)
+            .setDiskMb(1)
+            .build();
+    }
+
+    protected static CassandraFrameworkProtos.TaskResources resources(double cores, long mem, long disk) {
+        return CassandraFrameworkProtos.TaskResources.newBuilder()
+            .setCpuCores(cores)
+            .setMemMb(mem)
+            .setDiskMb(disk)
+            .build();
+    }
+}

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraClusterStateTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/CassandraClusterStateTest.java
@@ -185,6 +185,7 @@ public class CassandraClusterStateTest extends AbstractSchedulerTest {
 
         if (nodeCount >= 0)
             assertEquals(nodeCount, cluster.getClusterState().get().getNodesCount());
+        assertNotNull(tasksForOffer);
         assertTrue(tasksForOffer.hasExecutor());
         assertEquals(1, tasksForOffer.getLaunchTasks().size());
         assertEquals(0, tasksForOffer.getSubmitTasks().size());

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ChangeSeedStatusTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ChangeSeedStatusTest.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+import org.apache.mesos.Protos;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class ChangeSeedStatusTest extends AbstractCassandraSchedulerTest {
+
+    @Test
+    public void testSeedChanged() throws Exception {
+
+        cleanState();
+
+        assertEquals(2, clusterState.get().getSeedsToAcquire());
+
+        // rollout slaves
+        executorMetadata = new Protos.TaskInfo[slaves.length];
+        executorMetadata[0] = launchExecutor(slaves[0], 1);
+
+        try {
+            cluster.setNodeSeed(cluster.findNode(slaves[0]._2), false);
+            fail();
+        } catch (SeedChangeException e) {
+            assertEquals("Must not change seed status while initial number of seed nodes has not been acquired", e.getMessage());
+        }
+
+        assertEquals(1, clusterState.get().getSeedsToAcquire());
+        executorMetadata[1] = launchExecutor(slaves[1], 2);
+        assertEquals(0, clusterState.get().getSeedsToAcquire());
+        executorMetadata[2] = launchExecutor(slaves[2], 3);
+        assertEquals(0, clusterState.get().getSeedsToAcquire());
+
+        threeNodeClusterPost();
+
+        assertFalse(cluster.setNodeSeed(cluster.findNode(slaves[0]._2), true));
+        assertFalse(cluster.setNodeSeed(cluster.findNode(slaves[1]._2), true));
+        assertFalse(cluster.setNodeSeed(cluster.findNode(slaves[2]._2), false));
+
+        for (CassandraFrameworkProtos.CassandraNode cassandraNode : clusterState.nodes()) {
+            assertFalse(cassandraNode.getNeedsConfigUpdate());
+        }
+
+        noopOnOffer(slaves[0], 3);
+        noopOnOffer(slaves[1], 3);
+        noopOnOffer(slaves[2], 3);
+
+        // make 3rd node a seed
+
+        assertTrue(cluster.setNodeSeed(cluster.findNode(slaves[2]._2), true));
+        for (CassandraFrameworkProtos.CassandraNode cassandraNode : clusterState.nodes()) {
+            assertTrue(cassandraNode.getNeedsConfigUpdate());
+        }
+
+        // verify UPDATE_CONFIG tasks are launched
+        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
+        launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
+        launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
+        noopOnOffer(slaves[0], 3);
+        noopOnOffer(slaves[1], 3);
+        noopOnOffer(slaves[2], 3);
+
+        for (CassandraFrameworkProtos.CassandraNode cassandraNode : clusterState.nodes()) {
+            assertFalse(cassandraNode.getNeedsConfigUpdate());
+        }
+
+        // make 1st node not a seed
+        assertTrue(cluster.setNodeSeed(cluster.findNode(slaves[0]._2), false));
+        for (CassandraFrameworkProtos.CassandraNode cassandraNode : clusterState.nodes()) {
+            assertTrue(cassandraNode.getNeedsConfigUpdate());
+        }
+
+        // verify UPDATE_CONFIG tasks are launched
+        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
+        launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
+        launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.UPDATE_CONFIG);
+        noopOnOffer(slaves[0], 3);
+        noopOnOffer(slaves[1], 3);
+        noopOnOffer(slaves[2], 3);
+
+        for (CassandraFrameworkProtos.CassandraNode cassandraNode : clusterState.nodes()) {
+            assertFalse(cassandraNode.getNeedsConfigUpdate());
+        }
+
+        // mark two nodes as deas so that last remaining (seed) cannot be made non-seed
+        sendHealthCheckResult(executorMetadata[2], healthCheckDetailsFailed());
+
+        try {
+            cluster.setNodeSeed(cluster.findNode(slaves[1]._2), false);
+            fail();
+        } catch (SeedChangeException e) {
+            assertEquals("Must not remove the last live seed node", e.getMessage());
+        }
+    }
+
+}

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ClusterRestartTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ClusterRestartTest.java
@@ -1,0 +1,247 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+import io.mesosphere.mesos.util.CassandraFrameworkProtosUtils;
+import io.mesosphere.mesos.util.Tuple2;
+import org.apache.mesos.Protos;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertNull;
+
+public class ClusterRestartTest extends AbstractCassandraSchedulerTest {
+
+    @Test
+    public void testClusterRestart() throws Exception {
+        threeNodeCluster();
+
+        CassandraFrameworkProtos.ClusterJobType clusterJobType = CassandraFrameworkProtos.ClusterJobType.RESTART;
+
+        CassandraFrameworkProtos.ClusterJobStatus currentClusterJob = cluster.getCurrentClusterJob();
+        assertNull(currentClusterJob);
+
+        // simulate API call
+        cluster.startClusterTask(clusterJobType);
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+
+        assertFalse(currentClusterJob.hasCurrentNode());
+        assertEquals(3, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+
+        String restartingExecutor;
+        Set<String> restartedExecutors = new HashSet<>();
+
+        for (int i = 0; i < activeNodes; i++) {
+
+            currentClusterJob = cluster.getCurrentClusterJob();
+            assertNotNull(currentClusterJob);
+            assertFalse(currentClusterJob.hasCurrentNode());
+
+            noopOnOfferAll();
+
+            currentClusterJob = cluster.getCurrentClusterJob();
+            assertNotNull(currentClusterJob);
+            assertTrue(currentClusterJob.hasCurrentNode());
+
+            restartingExecutor = currentClusterJob.getCurrentNode().getExecutorId();
+            assertTrue(restartedExecutors.add(restartingExecutor));
+
+            // check that node is in RESTART state
+            CassandraFrameworkProtos.CassandraNode node = cluster.findNode(restartingExecutor);
+            assertNotNull(node);
+            assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node.getTargetRunState());
+
+            // simulate server-task stopped
+            CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
+            assertNotNull(taskForNode);
+
+            Tuple2<Protos.SlaveID, String> slave = slaveForExecutor(restartingExecutor);
+            assertNotNull(slave);
+            Protos.TaskInfo execMetadata = execForExecutor(restartingExecutor);
+            assertNotNull(execMetadata);
+            Tuple2<Protos.TaskInfo, CassandraFrameworkProtos.TaskDetails> execServer = serverTaskForExecutor(restartingExecutor);
+            assertNotNull(execServer);
+
+            // verify that kill-task is launched
+            killTask(slave, taskForNode.getTaskId());
+            // must not repeat CASSANDRA_SERVER_SHUTDOWN since it's already launched
+            noopOnOffer(slave, 3, true);
+
+            // simulate server-task has finished
+            executorTaskFinished(execServer._1, CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+                .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NULL_DETAILS)
+                .build());
+
+            // check that server-task is no longer present
+            node = cluster.findNode(restartingExecutor);
+            assertNotNull(node);
+            assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
+
+            // must have current-node - server task not running
+            currentClusterJob = cluster.getCurrentClusterJob();
+            assertNotNull(currentClusterJob);
+            assertTrue(currentClusterJob.hasCurrentNode());
+            assertEquals(restartingExecutor, currentClusterJob.getCurrentNode().getExecutorId());
+
+            // verify that CASSANDRA_SERVER_RUN task is launched
+            launchTask(slave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+            // must not repeat CASSANDRA_SERVER_RUN since it's already launched
+            noopOnOffer(slave, 3, true);
+
+            // must have current-node - no valid HC received yet
+            currentClusterJob = cluster.getCurrentClusterJob();
+            assertNotNull(currentClusterJob);
+            assertTrue(currentClusterJob.hasCurrentNode());
+            assertEquals(restartingExecutor, currentClusterJob.getCurrentNode().getExecutorId());
+
+            executorTaskRunning(execServer._1);
+            sendHealthCheckResult(execMetadata, healthCheckDetailsSuccess("NORMAL", true));
+
+            noopOnOffer(slave, 3, true);
+
+        }
+
+        assertThat(restartedExecutors).hasSize(activeNodes);
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNull(currentClusterJob);
+    }
+
+    @Test
+    public void testClusterRestartWithStoppedNode() throws Exception {
+        threeNodeCluster();
+
+        CassandraFrameworkProtos.ClusterJobType clusterJobType = CassandraFrameworkProtos.ClusterJobType.RESTART;
+
+        CassandraFrameworkProtos.ClusterJobStatus currentClusterJob = cluster.getCurrentClusterJob();
+        assertNull(currentClusterJob);
+
+        // stop node 2
+        CassandraFrameworkProtos.CassandraNode node2 = cluster.nodeStop(slaves[1]._2);
+        assertNotNull(node2);
+        CassandraFrameworkProtos.CassandraNodeTask node1serverTask = CassandraFrameworkProtosUtils.getTaskForNode(node2, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
+        assertNotNull(node1serverTask);
+        killTask(slaves[1], node1serverTask.getTaskId());
+        // simulate server-task has finished
+        executorTaskFinished(executorServer[1]._1, CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+            .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NULL_DETAILS)
+            .build());
+
+
+        // simulate API call
+        cluster.startClusterTask(clusterJobType);
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNotNull(currentClusterJob);
+
+        assertFalse(currentClusterJob.hasCurrentNode());
+        assertEquals(3, currentClusterJob.getRemainingNodesCount());
+        assertEquals(0, currentClusterJob.getCompletedNodesCount());
+        assertEquals(clusterJobType, currentClusterJob.getJobType());
+        assertFalse(currentClusterJob.getAborted());
+        assertTrue(currentClusterJob.hasStartedTimestamp());
+        assertFalse(currentClusterJob.hasFinishedTimestamp());
+
+        String restartingExecutor;
+        Set<String> restartedExecutors = new HashSet<>();
+
+        for (int i = 0; i < activeNodes - 1; i++) {
+
+            currentClusterJob = cluster.getCurrentClusterJob();
+            assertNotNull(currentClusterJob);
+            assertFalse(currentClusterJob.hasCurrentNode());
+
+            noopOnOfferAll();
+
+            currentClusterJob = cluster.getCurrentClusterJob();
+            assertNotNull(currentClusterJob);
+            assertTrue(currentClusterJob.hasCurrentNode());
+
+            restartingExecutor = currentClusterJob.getCurrentNode().getExecutorId();
+            assertTrue(restartedExecutors.add(restartingExecutor));
+            // verify that the stopped node is NOT restarted
+            assertNotEquals(executorMetadata[1].getExecutor().getExecutorId(), restartingExecutor);
+
+            // check that node is in RESTART state
+            CassandraFrameworkProtos.CassandraNode node = cluster.findNode(restartingExecutor);
+            assertNotNull(node);
+            assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node.getTargetRunState());
+
+            // simulate server-task stopped
+            CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
+            assertNotNull(taskForNode);
+
+            Tuple2<Protos.SlaveID, String> slave = slaveForExecutor(restartingExecutor);
+            assertNotNull(slave);
+            Protos.TaskInfo execMetadata = execForExecutor(restartingExecutor);
+            assertNotNull(execMetadata);
+            Tuple2<Protos.TaskInfo, CassandraFrameworkProtos.TaskDetails> execServer = serverTaskForExecutor(restartingExecutor);
+            assertNotNull(execServer);
+
+            // verify that kill-task is launched
+            killTask(slave, taskForNode.getTaskId());
+            // must not repeat CASSANDRA_SERVER_SHUTDOWN since it's already launched
+            noopOnOffer(slave, 3, true);
+
+            // simulate server-task has finished
+            executorTaskFinished(execServer._1, CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+                .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NULL_DETAILS)
+                .build());
+
+            // check that server-task is no longer present
+            node = cluster.findNode(restartingExecutor);
+            assertNotNull(node);
+            assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
+
+            // must have current-node - server task not running
+            currentClusterJob = cluster.getCurrentClusterJob();
+            assertNotNull(currentClusterJob);
+            assertTrue(currentClusterJob.hasCurrentNode());
+            assertEquals(restartingExecutor, currentClusterJob.getCurrentNode().getExecutorId());
+
+            // verify that CASSANDRA_SERVER_RUN task is launched
+            launchTask(slave, CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+            // must not repeat CASSANDRA_SERVER_RUN since it's already launched
+            noopOnOffer(slave, 3, true);
+
+            // must have current-node - no valid HC received yet
+            currentClusterJob = cluster.getCurrentClusterJob();
+            assertNotNull(currentClusterJob);
+            assertTrue(currentClusterJob.hasCurrentNode());
+            assertEquals(restartingExecutor, currentClusterJob.getCurrentNode().getExecutorId());
+
+            executorTaskRunning(execServer._1);
+            sendHealthCheckResult(execMetadata, healthCheckDetailsSuccess("NORMAL", true));
+
+            noopOnOffer(slave, 3, true);
+
+        }
+
+        assertThat(restartedExecutors).hasSize(activeNodes - 1);
+
+        currentClusterJob = cluster.getCurrentClusterJob();
+        assertNull(currentClusterJob);
+    }
+}

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/NodeScaleOutTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/NodeScaleOutTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class NodeScaleOutTest extends AbstractCassandraSchedulerTest {
+
+    @Test
+    public void testNodeTargetStateShutdownAndRun() throws Exception {
+
+        threeNodeCluster();
+
+        noopOnOffer(slaves[0], 3);
+        noopOnOffer(slaves[1], 3);
+        noopOnOffer(slaves[2], 3);
+
+        assertEquals(0, cluster.getClusterState().get().getNodesToAcquire());
+
+        cluster.updateNodeCount(4);
+
+        assertEquals(1, cluster.getClusterState().get().getNodesToAcquire());
+
+        startFourthNode();
+
+        assertEquals(0, cluster.getClusterState().get().getNodesToAcquire());
+
+        fourthNodeRunning();
+    }
+
+}

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/NodeTargetStateTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/NodeTargetStateTest.java
@@ -1,0 +1,220 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.mesosphere.mesos.util.CassandraFrameworkProtosUtils;
+import org.apache.mesos.Protos;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class NodeTargetStateTest extends AbstractCassandraSchedulerTest {
+
+    @Test
+    public void testNonExistant() throws InvalidProtocolBufferException {
+        threeNodeCluster();
+
+        assertNull(cluster.nodeStop("42"));
+        assertNull(cluster.nodeRun("42"));
+        assertNull(cluster.nodeTerminate("42"));
+        assertNull(cluster.nodeRestart("42"));
+    }
+
+    @Test
+    public void testNodeTargetStateShutdownAndRun() throws Exception {
+
+        threeNodeCluster();
+
+        noopOnOffer(slaves[0], 3);
+        noopOnOffer(slaves[1], 3);
+        noopOnOffer(slaves[2], 3);
+
+        assertNull(cluster.nodeStop("foo bar baz"));
+
+        CassandraFrameworkProtos.CassandraNode node1 = cluster.nodeStop(slaves[0]._2);
+        assertNotNull(node1);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.STOP, node1.getTargetRunState());
+
+        CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
+        assertNotNull(taskForNode);
+
+        // verify that kill-task is launched
+        killTask(slaves[0], taskForNode.getTaskId());
+        // must not repeat CASSANDRA_SERVER_SHUTDOWN since it's already launched
+        noopOnOffer(slaves[0], 3, true);
+
+        // re-check that server-task is still present
+        node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
+        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
+
+        // simulate server-task has finished
+        executorTaskFinished(executorServer[0]._1, CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+            .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NULL_DETAILS)
+            .build());
+
+        // check that server-task is no longer present
+        node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
+        assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
+
+
+        // now start node
+
+        node1 = cluster.nodeRun(slaves[0]._2);
+        assertNotNull(node1);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RUN, node1.getTargetRunState());
+
+        // verify that CASSANDRA_SERVER_RUN task is launched
+        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+        // must not repeat CASSANDRA_SERVER_RUN since it's already launched
+        noopOnOffer(slaves[0], 3);
+
+        // check that server-task is present
+        node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RUN, node1.getTargetRunState());
+        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
+
+        // simulate server-task is running
+        sendHealthCheckResult(executorMetadata[0], healthCheckDetailsSuccess("NORMAL", true));
+
+
+        // TERMINATE
+
+        node1 = cluster.nodeTerminate(slaves[0]._2);
+        assertNotNull(node1);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.TERMINATE, node1.getTargetRunState());
+
+        taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
+        assertNotNull(taskForNode);
+
+        // verify that kill-task is launched
+        killTask(slaves[0], taskForNode.getTaskId());
+        // must not repeat CASSANDRA_SERVER_SHUTDOWN since it's already launched
+        noopOnOffer(slaves[0], 3, true);
+
+        // re-check that server-task is still present
+        node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
+        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
+
+        // simulate server-task has finished
+        executorTaskFinished(executorServer[0]._1, CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+            .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NULL_DETAILS)
+            .build());
+
+        // check that server-task is no longer present
+        node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
+        assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
+
+        // try RUN
+
+        node1 = cluster.nodeRun(slaves[0]._2);
+        assertNotNull(node1);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.TERMINATE, node1.getTargetRunState());
+
+        // try STOP
+
+        node1 = cluster.nodeStop(slaves[0]._2);
+        assertNotNull(node1);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.TERMINATE, node1.getTargetRunState());
+
+        // try RESTART
+
+        node1 = cluster.nodeRestart(slaves[0]._2);
+        assertNotNull(node1);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.TERMINATE, node1.getTargetRunState());
+
+
+    }
+
+    @Test
+    public void testNodeTargetStateRestart() throws Exception {
+
+        threeNodeCluster();
+
+        noopOnOffer(slaves[0], 3);
+        noopOnOffer(slaves[1], 3);
+        noopOnOffer(slaves[2], 3);
+
+        assertNull(cluster.nodeRestart("foo bar baz"));
+
+        CassandraFrameworkProtos.CassandraNode node1 = cluster.nodeRestart(slaves[0]._2);
+        assertNotNull(node1);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node1.getTargetRunState());
+
+        CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
+        assertNotNull(taskForNode);
+
+        // verify that kill-task is launched
+        killTask(slaves[0], taskForNode.getTaskId());
+        // must not repeat CASSANDRA_SERVER_SHUTDOWN since it's already launched
+        noopOnOffer(slaves[0], 3, true);
+
+        // re-check that server-task is still present
+        node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node1.getTargetRunState());
+        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
+
+        // simulate server-task has finished
+        executorTaskFinished(executorServer[0]._1, CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+            .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NULL_DETAILS)
+            .build());
+
+        // check that server-task is no longer present
+        node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RESTART, node1.getTargetRunState());
+        assertNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
+
+
+
+        // verify that CASSANDRA_SERVER_RUN task is launched
+        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+        // must not repeat CASSANDRA_SERVER_RUN since it's already launched
+        noopOnOffer(slaves[0], 3);
+
+        // check that server-task is present
+        node1 = cluster.findNode(slaves[0]._2);
+        assertNotNull(node1);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.RUN, node1.getTargetRunState());
+        assertNotNull(CassandraFrameworkProtosUtils.getTaskForNode(node1, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
+
+        // simulate server-task is running
+        sendHealthCheckResult(executorMetadata[0], healthCheckDetailsSuccess("NORMAL", true));
+
+    }
+
+    @Test
+    public void testServerTaskRemove() throws InvalidProtocolBufferException {
+
+        Protos.TaskInfo[] executorMetadata = threeNodeCluster();
+
+        // cluster now up with 3 running nodes
+
+        // server-task no longer running
+        executorTaskError(executorMetadata[0]);
+
+        // server-task cannot start again
+        launchExecutor(slaves[0], 3);
+        executorTaskRunning(executorMetadata[0]);
+        launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+
+    }
+
+}

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/RepairCleanupTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/RepairCleanupTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import org.junit.Test;
+
+public class RepairCleanupTest extends AbstractCassandraSchedulerTest {
+
+    @Test
+    public void testRepair() throws InvalidProtocolBufferException {
+
+        threeNodeCluster();
+
+        clusterJob(CassandraFrameworkProtos.ClusterJobType.REPAIR);
+
+        clusterJob(CassandraFrameworkProtos.ClusterJobType.REPAIR);
+
+        clusterJobAbort(CassandraFrameworkProtos.ClusterJobType.REPAIR);
+
+        clusterJobFailingNode(CassandraFrameworkProtos.ClusterJobType.REPAIR);
+
+    }
+
+    @Test
+    public void testRepairCleanupRepairCleanup() throws InvalidProtocolBufferException {
+
+        threeNodeCluster();
+
+        clusterJob(CassandraFrameworkProtos.ClusterJobType.REPAIR);
+
+        clusterJob(CassandraFrameworkProtos.ClusterJobType.CLEANUP);
+
+        clusterJobAbort(CassandraFrameworkProtos.ClusterJobType.REPAIR);
+
+        clusterJobAbort(CassandraFrameworkProtos.ClusterJobType.CLEANUP);
+
+    }
+
+    @Test
+    public void testRepairWithFailingNode() throws InvalidProtocolBufferException {
+
+        threeNodeCluster();
+
+        partiallyFailingClusterJob(CassandraFrameworkProtos.ClusterJobType.REPAIR);
+
+        partiallyFailingClusterJob(CassandraFrameworkProtos.ClusterJobType.REPAIR);
+
+    }
+
+}

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ReplaceNodeTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ReplaceNodeTest.java
@@ -1,0 +1,213 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.mesosphere.mesos.frameworks.cassandra;
+
+import io.mesosphere.mesos.util.CassandraFrameworkProtosUtils;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.*;
+
+public class ReplaceNodeTest extends AbstractCassandraSchedulerTest {
+
+    @Test
+    public void testReplaceNodePrerequirements() throws Exception {
+        cleanState();
+
+        try {
+            // non-existing node
+            cluster.replaceNode("foobar");
+            fail();
+        } catch (ReplaceNodePreconditionFailed e) {
+            assertTrue(e.getMessage().startsWith("Non-existing node "));
+        }
+
+        CassandraFrameworkProtos.CassandraNode.Builder node = CassandraFrameworkProtos.CassandraNode.newBuilder()
+            .setHostname("bart")
+            .setIp("1.2.3.4")
+            .setSeed(true)
+            .setTargetRunState(CassandraFrameworkProtos.CassandraNode.TargetRunState.RUN)
+            .setJmxConnect(CassandraFrameworkProtos.JmxConnect.newBuilder().setIp("1.2.3.4").setJmxPort(7199))
+            .setCassandraNodeExecutor(CassandraFrameworkProtos.CassandraNodeExecutor.newBuilder()
+                .addCommand("cmd")
+                .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
+                    .setCpuCores(1)
+                    .setDiskMb(1)
+                    .setMemMb(1))
+                .setExecutorId("exec")
+                .setSource("src"))
+            .addTasks(CassandraFrameworkProtos.CassandraNodeTask.newBuilder()
+                .setResources(CassandraFrameworkProtos.TaskResources.newBuilder()
+                    .setCpuCores(1)
+                    .setDiskMb(1)
+                    .setMemMb(1))
+                .setTaskId("task")
+                .setType(CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER));
+        cluster.getClusterState().addOrSetNode(node.build());
+        CassandraFrameworkProtos.HealthCheckDetails.Builder hcd = CassandraFrameworkProtos.HealthCheckDetails.newBuilder()
+            .setHealthy(true)
+            .setInfo(CassandraFrameworkProtos.NodeInfo.newBuilder()
+                .setRpcServerRunning(true)
+                .setNativeTransportRunning(true));
+        cluster.recordHealthCheck("exec", hcd.build());
+        assertTrue(cluster.isLiveNode(cluster.findNode("exec")));
+        assertTrue(cluster.isLiveNode(cluster.findNode("bart")));
+        assertTrue(cluster.isLiveNode(cluster.findNode("1.2.3.4")));
+
+        try {
+            cluster.replaceNode("bart");
+            fail();
+        } catch (ReplaceNodePreconditionFailed e) {
+            assertTrue(e.getMessage().endsWith("to replace is a seed node"));
+        }
+
+        cluster.getClusterState().addOrSetNode(node
+            .setSeed(false)
+            .build());
+
+        try {
+            cluster.replaceNode("bart");
+            fail();
+        } catch (ReplaceNodePreconditionFailed e) {
+            assertTrue(e.getMessage().startsWith("Cannot replace live node "));
+        }
+
+        hcd.setHealthy(false)
+            .setInfo(CassandraFrameworkProtos.NodeInfo.newBuilder()
+                .setRpcServerRunning(false)
+                .setNativeTransportRunning(false));
+        cluster.recordHealthCheck("exec", hcd.build());
+
+        try {
+            cluster.replaceNode("bart");
+            fail();
+        } catch (ReplaceNodePreconditionFailed e) {
+            assertTrue(e.getMessage().startsWith("Cannot replace non-terminated node "));
+        }
+
+        cluster.getClusterState().addOrSetNode(node
+            .setTargetRunState(CassandraFrameworkProtos.CassandraNode.TargetRunState.TERMINATE)
+            .build());
+
+        try {
+            cluster.replaceNode("1.2.3.4");
+            fail();
+        } catch (ReplaceNodePreconditionFailed e) {
+            assertTrue(e.getMessage().endsWith(" to replace has active tasks"));
+        }
+
+        cluster.getClusterState().addOrSetNode(node
+            .clearTasks()
+            .build());
+
+        cluster.replaceNode("exec");
+
+        try {
+            cluster.replaceNode("bart");
+            fail();
+        } catch (ReplaceNodePreconditionFailed e) {
+            assertTrue(e.getMessage().endsWith(" already in replace-list"));
+        }
+
+    }
+
+    @Test
+    public void testNodeReplace() throws Exception {
+
+        threeNodeCluster();
+
+        CassandraFrameworkProtos.CassandraNode node3 = cluster.nodeTerminate(slaves[2]._2);
+        assertNotNull(node3);
+        assertEquals(CassandraFrameworkProtos.CassandraNode.TargetRunState.TERMINATE, node3.getTargetRunState());
+
+        CassandraFrameworkProtos.CassandraNodeTask taskForNode = CassandraFrameworkProtosUtils.getTaskForNode(node3, CassandraFrameworkProtos.CassandraNodeTask.NodeTaskType.SERVER);
+        assertNotNull(taskForNode);
+
+        // verify that kill-task is launched
+        killTask(slaves[2], taskForNode.getTaskId());
+        // must not repeat kill-task since it's already launched
+        noopOnOffer(slaves[2], 3, true);
+
+        // simulate server-task has finished
+        executorTaskFinished(executorServer[2]._1, CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+            .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NULL_DETAILS)
+            .build());
+
+        killTask(slaves[2], node3.getCassandraNodeExecutor().getExecutorId());
+        // must not repeat kill-task since it's already launched
+        noopOnOffer(slaves[2], 3, true);
+
+        try {
+            cluster.replaceNode(slaves[2]._2);
+            fail();
+        } catch (ReplaceNodePreconditionFailed ignored) {
+            // ignored
+        }
+
+        // simulate server-task has finished
+        executorTaskFinished(executorServer[2]._1, CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+            .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NULL_DETAILS)
+            .build());
+
+        try {
+            cluster.replaceNode(slaves[2]._2);
+            fail();
+        } catch (ReplaceNodePreconditionFailed ignored) {
+            // ignored
+        }
+
+        // simulate executor has finished
+        executorTaskFinished(executorMetadata[2], CassandraFrameworkProtos.SlaveStatusDetails.newBuilder()
+            .setStatusDetailsType(CassandraFrameworkProtos.SlaveStatusDetails.StatusDetailsType.NULL_DETAILS)
+            .build());
+
+
+        // replace the node
+
+        node3 = cluster.replaceNode(slaves[2]._2);
+        assertNotNull(node3);
+
+        assertEquals(1, cluster.getClusterState().get().getReplaceNodeIpsCount());
+
+        assertEquals(3, cluster.getClusterState().get().getNodesCount());
+
+        // add 4th node (as replacement)
+
+        startFourthNode();
+
+        assertThat(cluster.getClusterState().get().getReplaceNodeIpsList()).isEmpty();
+        assertEquals(4, cluster.getClusterState().get().getNodesCount());
+
+        List<String> args = executorServer[3]._2.getCassandraServerRunTask().getCommandList();
+        assertThat(args).contains("-Dcassandra.replace_address=" + slaves[2]._2);
+
+        node3 = cluster.findNode(slaves[3]._2);
+        assertNotNull(node3);
+        assertTrue(node3.hasReplacementForIp());
+
+        fourthNodeRunning();
+
+        // replaced node should have been removed from our nodes list
+        assertEquals(3, cluster.getClusterState().get().getNodesCount());
+
+        assertNull(cluster.findNode(slaves[2]._2));
+
+        node3 = cluster.findNode(slaves[3]._2);
+        assertNotNull(node3);
+        assertFalse(node3.hasReplacementForIp());
+    }
+
+}


### PR DESCRIPTION
* split utests in CassandraSchedulerTests into separate source files
* fix mesos-resource-role matchin (match everything on `*`)
* fix buggy cluster job state handling when executor is lost or task is lost
* add more utests + enhance existing utests (should increase code coverage)
* fix buggy change-seed code