### PR TITLE
Cleanups

### DIFF
--- a/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
+++ b/cassandra-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/CassandraCluster.java
@@ -301,8 +301,6 @@ public final class CassandraCluster {
                     nodeOpt.get().hasCassandraNodeExecutor() ? nodeOpt.get().getCassandraNodeExecutor().getExecutorId() : nodeOpt.get().getHostname(),
                     details.getMsg()
                 );
-                // TODO: This needs to be smarter, right not it assumes that as soon as it's unhealth it's dead
-                //removeTask(nodeOpt.get().getServerTask().getTaskId());
             } else {
                 // upon the first healthy response clear the replacementForIp field
                 CassandraNodeTask serverTask = CassandraFrameworkProtosUtils.getTaskForNode(nodeOpt.get(), CassandraNodeTask.NodeTaskType.SERVER);

--- a/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
+++ b/cassandra-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/ApiControllerTest.java
@@ -696,7 +696,7 @@ public class ApiControllerTest extends AbstractCassandraSchedulerTest {
 
         try {
             try (ServerSocket sock = new ServerSocket(0)) {
-                httpServerBaseUri = URI.create(String.format("http://%s:%d/", formatInetAddress(InetAddress.getLocalHost()), sock.getLocalPort()));
+                httpServerBaseUri = URI.create(String.format("http://%s:%d/", formatInetAddress(InetAddress.getLoopbackAddress()), sock.getLocalPort()));
             }
 
             final ResourceConfig rc = new ResourceConfig()


### PR DESCRIPTION
Some more cleanups separated in different commits:

* Unit tests run on localhost (NIT - feel free to omit this)
* some NIT commits (ed4dd60, e936899)
* Add check of resources in offer for new nodes (don't acquire nodes that can never fulfil resource requirements)
* Make `CassandraNode.cassandraNodeExecutor` required and initialize it when building `CassandraNode` (we never clear that field)
* bugfix to only issue node-jobs to nodes that have target-run-state `RUN` and are considered live
* fix slow shutdown own server task (close of JMX connection takes very long if remote is gone)
* fix handling in scheduler when mesos-slave is killed