### PR TITLE
Cassandra 2.1.4

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -236,7 +236,7 @@ EXECUTOR_FILE_PATH=${PROJECT_DIR}/cassandra-mesos-executor/target/cassandra-meso
 # the jre, and it doesn't have to be provided by the slave host.
 JRE_FILE_PATH=${PROJECT_DIR}/target/framework-package/jdk.tar.gz
 
-# The file path to where a tar of Apache Cassandra 2.1.2 is on the local file system.
+# The file path to where a tar of Apache Cassandra 2.1.4 is on the local file system.
 # This file will be served by the build-in http server so that tasks will be able to easily access
 # the cassandra server, and it doesn't have to be provided by the slave host.
 CASSANDRA_FILE_PATH=${PROJECT_DIR}/target/framework-package/cassandra.tar.gz

--- a/README.markdown
+++ b/README.markdown
@@ -270,6 +270,32 @@ Environment variables:
 Command line options:
 * `--limit N` the number of live nodes to use. Has no effect for cqlsh or nodetool.
 
+## Important security notice
+
+CVE-2015-0225 describes a security vulnerability in Cassandra, which allows an attacker to execute arbitrary code via
+JMX/RMI.
+
+Some non-critical tools of Cassandra-on-Mesos framework rely on some functionality via JMX to be available remotely.
+
+1. `com-nodetool` (as `nodetool` itself) requires the JMX port to be open from outside. 
+1. `com-qa-report` uses `com-nodetool` for some functionality, means, it requires the JMX port to be open from outside.
+
+Do **not** open JMX port without authentication and SSL and proper firewall rules unless you know exactly what you
+are doing! Opening the JMX port will make your Cassandra nodes vulnerable to the security risk.
+If you are really sure that you explicitly want to expose the JMX port, you can pass the environment variables
+`CASSANDRA_JMX_LOCAL=false` and `CASSANDRA_JMX_NO_AUTHENTICATION=true` to the framework upon **initial** invocation
+(i.e. when the framework first registers).
+
+However [CASSANDRA-9089](https://issues.apache.org/jira/browse/CASSANDRA-9089) is meant to let JMX listen to a
+specific IP address, but is is not included in Cassandra 2.1.4.
+
+References:
+
+* [Security announcement](http://www.mail-archive.com/user@cassandra.apache.org/msg41819.html)
+* [CASSANDRA-9085](https://issues.apache.org/jira/browse/CASSANDRA-9085)
+* [JMX security](https://wiki.apache.org/cassandra/JmxSecurity)
+* [JMX agent](http://docs.oracle.com/javase/7/docs/technotes/guides/management/agent.html)
+
 ## Live Cassandra nodes API
 
 This framework provides API endpoints for most tools. All you need is `curl` and the hostname/IP of

--- a/cassandra-mesos-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/executor/CassandraExecutorTest.java
+++ b/cassandra-mesos-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/executor/CassandraExecutorTest.java
@@ -254,7 +254,7 @@ public class CassandraExecutorTest {
             CassandraFrameworkProtos.TaskDetails.newBuilder()
                 .setType(CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN)
                 .setCassandraServerRunTask(CassandraFrameworkProtos.CassandraServerRunTask.newBuilder()
-                    .setVersion("2.1.2")
+                    .setVersion("2.1.4")
                     .addCommand("somewhere")
                     .setCassandraServerConfig(CassandraFrameworkProtos.CassandraServerConfig.newBuilder()
                         .setCassandraYamlConfig(CassandraFrameworkProtos.TaskConfig.newBuilder())

--- a/cassandra-mesos-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/executor/TestObjectFactory.java
+++ b/cassandra-mesos-executor/src/test/java/io/mesosphere/mesos/frameworks/cassandra/executor/TestObjectFactory.java
@@ -150,6 +150,11 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
+        public boolean isStarting() {
+            return false;
+        }
+
+        @Override
         public String getReleaseVersion() {
             return "5.6.7";
         }
@@ -391,12 +396,22 @@ class TestObjectFactory implements ObjectFactory {
         }
 
         @Override
-        public int forceRepairRangeAsync(String beginToken, String endToken, String keyspaceName, boolean isSequential, Collection<String> dataCenters, Collection<String> hosts, boolean repairedAt, String... columnFamilies) {
+        public int forceRepairAsync(String keyspace, int parallelismDegree, Collection<String> dataCenters, Collection<String> hosts, boolean primaryRange, boolean fullRepair, String... columnFamilies) {
             throw new UnsupportedOperationException();
         }
 
         @Override
         public int forceRepairRangeAsync(String beginToken, String endToken, String keyspaceName, boolean isSequential, boolean isLocal, boolean repairedAt, String... columnFamilies) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int forceRepairRangeAsync(String beginToken, String endToken, String keyspaceName, boolean isSequential, Collection<String> dataCenters, Collection<String> hosts, boolean repairedAt, String... columnFamilies) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int forceRepairRangeAsync(String beginToken, String endToken, String keyspaceName, int parallelismDegree, Collection<String> dataCenters, Collection<String> hosts, boolean fullRepair, String... columnFamilies) {
             throw new UnsupportedOperationException();
         }
 

--- a/cassandra-mesos-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/framework/Main.java
+++ b/cassandra-mesos-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/framework/Main.java
@@ -180,7 +180,7 @@ public final class Main {
         );
 
         final ResourceConfig rc = new ResourceConfig()
-            .register(new FileResourceController())
+            .register(new FileResourceController(cassandraVersion))
             .register(new ApiController(cassandraCluster));
             //.packages("io.mesosphere.mesos.frameworks.cassandra");
         final HttpServer httpServer = GrizzlyHttpServerFactory.createHttpServer(httpServerBaseUri, rc);

--- a/cassandra-mesos-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/framework/Main.java
+++ b/cassandra-mesos-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/framework/Main.java
@@ -111,7 +111,7 @@ public final class Main {
         final long      javaHeapMb              = Long.parseLong(       Env.option("CASSANDRA_RESOURCE_HEAP_MB").or("0"));
         final long      healthCheckIntervalSec  = Long.parseLong(       Env.option("CASSANDRA_HEALTH_CHECK_INTERVAL_SECONDS").or("60"));
         final long      bootstrapGraceTimeSec   = Long.parseLong(       Env.option("CASSANDRA_BOOTSTRAP_GRACE_TIME_SECONDS").or("120"));
-        final String    cassandraVersion        =                       "2.1.2"; // TODO Env.option("CASSANDRA_VERSION").or("2.1.2");
+        final String    cassandraVersion        =                       "2.1.4"; // TODO Env.option("CASSANDRA_VERSION").or("2.1.4");
         final String    frameworkName           = frameworkName(Env.option("FRAMEWORK_NAME"));
         final String    zkUrl                   =                       Env.option("CASSANDRA_ZK").or("zk://localhost:2181/cassandra-mesos");
         final long      zkTimeoutMs             = Long.parseLong(Env.option("CASSANDRA_ZK_TIMEOUT_MS").or("10000"));

--- a/cassandra-mesos-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/framework/Main.java
+++ b/cassandra-mesos-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/framework/Main.java
@@ -104,21 +104,23 @@ public final class Main {
         final int port0 = Integer.parseInt(portOption.get());
 
         final int       executorCount           = Integer.parseInt(     Env.option("CASSANDRA_NODE_COUNT").or("3"));
-        final int       seedCount               = Integer.parseInt(Env.option("CASSANDRA_SEED_COUNT").or("2"));
-        final double    resourceCpuCores        = Double.parseDouble(Env.option("CASSANDRA_RESOURCE_CPU_CORES").or("2.0"));
-        final long      resourceMemoryMegabytes = Long.parseLong(Env.option("CASSANDRA_RESOURCE_MEM_MB").or("2048"));
+        final int       seedCount               = Integer.parseInt(     Env.option("CASSANDRA_SEED_COUNT").or("2"));
+        final double    resourceCpuCores        = Double.parseDouble(   Env.option("CASSANDRA_RESOURCE_CPU_CORES").or("2.0"));
+        final long      resourceMemoryMegabytes = Long.parseLong(       Env.option("CASSANDRA_RESOURCE_MEM_MB").or("2048"));
         final long      resourceDiskMegabytes   = Long.parseLong(       Env.option("CASSANDRA_RESOURCE_DISK_MB").or("2048"));
         final long      javaHeapMb              = Long.parseLong(       Env.option("CASSANDRA_RESOURCE_HEAP_MB").or("0"));
         final long      healthCheckIntervalSec  = Long.parseLong(       Env.option("CASSANDRA_HEALTH_CHECK_INTERVAL_SECONDS").or("60"));
         final long      bootstrapGraceTimeSec   = Long.parseLong(       Env.option("CASSANDRA_BOOTSTRAP_GRACE_TIME_SECONDS").or("120"));
         final String    cassandraVersion        =                       "2.1.4"; // TODO Env.option("CASSANDRA_VERSION").or("2.1.4");
-        final String    frameworkName           = frameworkName(Env.option("FRAMEWORK_NAME"));
+        final String    frameworkName           = frameworkName(        Env.option("FRAMEWORK_NAME"));
         final String    zkUrl                   =                       Env.option("CASSANDRA_ZK").or("zk://localhost:2181/cassandra-mesos");
-        final long      zkTimeoutMs             = Long.parseLong(Env.option("CASSANDRA_ZK_TIMEOUT_MS").or("10000"));
+        final long      zkTimeoutMs             = Long.parseLong(       Env.option("CASSANDRA_ZK_TIMEOUT_MS").or("10000"));
         final String    mesosMasterZkUrl        =                       Env.option("MESOS_ZK").or("zk://localhost:2181/mesos");
-        final long      failoverTimeout         = Long.parseLong(Env.option("CASSANDRA_FAILOVER_TIMEOUT_SECONDS").or(String.valueOf(Period.days(7).toStandardSeconds().getSeconds())));
+        final long      failoverTimeout         = Long.parseLong(       Env.option("CASSANDRA_FAILOVER_TIMEOUT_SECONDS").or(String.valueOf(Period.days(7).toStandardSeconds().getSeconds())));
         final String    mesosRole               =                       Env.option("CASSANDRA_FRAMEWORK_MESOS_ROLE").or("*");
         final String    dataDirectory           =                       Env.option("CASSANDRA_DATA_DIRECTORY").or(DEFAULT_DATA_DIRECTORY);  // TODO: Temporary. Will be removed when MESOS-1554 is released
+        final boolean   jmxLocal                = Boolean.parseBoolean( Env.option("CASSANDRA_JMX_LOCAL").or("true"));
+        final boolean   jmxNoAuthentication     = Boolean.parseBoolean( Env.option("CASSANDRA_JMX_NO_AUTHENTICATION").or("false"));
 
         final Matcher matcher = validateZkUrl(zkUrl);
 
@@ -146,7 +148,9 @@ public final class Main {
             executorCount,
             seedCount,
             mesosRole,
-            dataDirectory);
+            dataDirectory,
+            jmxLocal,
+            jmxNoAuthentication);
 
 
         final FrameworkInfo.Builder frameworkBuilder =

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -90,49 +90,58 @@ message CassandraConfigRole {
      */
     required TaskResources resources = 5;
 
-    // Cassandra memory usage can be categorized into
-    // 1. Java heap (MAX_HEAP_SIZE) - including new-gen (HEAP_NEWSIZE)
-    //    Amount of Java heap in MB.
-    //    (defaults to 50% of memMb, max 16384, if not present)
+    /**
+     * Cassandra memory usage can be categorized into
+     * 1. Java heap (MAX_HEAP_SIZE) - including new-gen (HEAP_NEWSIZE)
+     *    Amount of Java heap in MB.
+     *    (defaults to 50% of memMb, max 16384, if not present)
+     * 2. Off-Heap
+     *    Amount of Off heap in MB.
+     *    (defaults to memMb - memJavaHeapMb, if not present)
+     * 3. OS (add as much as possible for OS block cache)
+     *     This is just the difference between memMb and memJavaHeapMb + memAssumeOffHeapMb
+     *  Production grade memory configuration should include all three memory configuration parameters above.
+     *  Do not forget to add as much memory for OS block cache as possible for improved performance.
+     *
+     *  Off-heap structures (C* 2.1):
+     *  - index-summary (default: 5% of the heap size)
+     *    configured in cassandra.yaml - see index_summary_capacity_in_mb
+     *    default to 5% of the heap size (may exceed)
+     *  - key-cache (default: 5% of the heap size)
+     *    configured in cassandra.yaml - see key_cache_size_in_mb
+     *    default to 5% of the heap size
+     *  - row-cache (default: off)
+     *    configured in cassandra.yaml - see row_cache_size_in_mb (must be explicitly enabled in taskEnv)
+     *    default to 0
+     *  - counter-cache (default: min(2.5% of Heap (in MB), 50MB))
+     *    configured in cassandra.yaml - see counter_cache_size_in_mb
+     *    default: min(2.5% of Heap (in MB), 50MB) ; 0 means no cache
+     *  - memtables (default on-heap)
+     *    configured in cassandra.yaml - see file_cache_size_in_mb
+     *    default to the smaller of 1/4 of heap or 512MB
+     *  - file-cache (default: min(25% of Heap (in MB), 512MB))
+     *    configured in cassandra.yaml - see file_cache_size_in_mb
+     *    default to the smaller of 1/4 of heap or 512MB
+     *  - overhead during flushes/compactions/cleanup
+     *    implicitly defined by workload
+     */
     optional int64 memJavaHeapMb = 6;
-    // 2. Off-Heap
-    //    Amount of Off heap in MB.
-    //    (defaults to memMb - memJavaHeapMb, if not present)
+    /**
+     * see memJavaHeapMb for details
+     */
     optional int64 memAssumeOffHeapMb = 7;
-    // 3. OS (add as much as possible for OS block cache)
-    //    This is just the difference between memMb and memJavaHeapMb + memAssumeOffHeapMb
 
-    // Production grade memory configuration should include all three memory configuration parameters above.
-    // Do not forget to add as much memory for OS block cache as possible for improved performance.
-
-    // Off-heap structures (C* 2.1):
-    // - index-summary (default: 5% of the heap size)
-    //   configured in cassandra.yaml - see index_summary_capacity_in_mb
-    //   default to 5% of the heap size (may exceed)
-    // - key-cache (default: 5% of the heap size)
-    //   configured in cassandra.yaml - see key_cache_size_in_mb
-    //   default to 5% of the heap size
-    // - row-cache (default: off)
-    //   configured in cassandra.yaml - see row_cache_size_in_mb (must be explicitly enabled in taskEnv)
-    //   default to 0
-    // - counter-cache (default: min(2.5% of Heap (in MB), 50MB))
-    //   configured in cassandra.yaml - see counter_cache_size_in_mb
-    //   default: min(2.5% of Heap (in MB), 50MB) ; 0 means no cache
-    // - memtables (default on-heap)
-    //   configured in cassandra.yaml - see file_cache_size_in_mb
-    //   default to the smaller of 1/4 of heap or 512MB
-    // - file-cache (default: min(25% of Heap (in MB), 512MB))
-    //   configured in cassandra.yaml - see file_cache_size_in_mb
-    //   default to the smaller of 1/4 of heap or 512MB
-    // - overhead during flushes/compactions/cleanup
-    //   implicitly defined by workload
-
-    // additional configuration
-    // process environment
+    /**
+     * additional configuration, process environment
+     */
     optional TaskEnv taskEnv = 8;
-    // cassandra.yaml configuration
+    /**
+     * cassandra.yaml configuration
+     */
     optional TaskConfig cassandraYamlConfig = 9;
-    // mesos role to be used to receive resource offers
+    /**
+     * mesos role to be used to receive resource offers
+     */
     optional string mesosRole = 10;
 
     /**
@@ -399,21 +408,31 @@ message CassandraNode {
     optional string replacementForIp = 13;
 
     enum TargetRunState {
-        // If the server task is not active, it is started.
-        // Note that general bootstrap-grace-time settings and other checks (e.g. currently other nodes joining) apply.
+        /**
+         * If the server task is not active, it is started.
+         * Note that general bootstrap-grace-time settings and other checks (e.g. currently other nodes joining) apply.
+         */
         RUN = 0;
-        // If the server-task is active, a server-task shutdown is initiated.
+        /**
+         * If the server-task is active, a server-task shutdown is initiated.
+         */
         STOP = 1;
-        // If the server task is not active, the state is immediately set to RUN.
-        // If the server-task is active, a server-task shutdown is initiated.
-        // Note that general bootstrap-grace-time settings and other checks (e.g. currently other nodes joining) apply.
+        /**
+         * If the server task is not active, the state is immediately set to RUN.
+         * If the server-task is active, a server-task shutdown is initiated.
+         * Note that general bootstrap-grace-time settings and other checks (e.g. currently other nodes joining) apply.
+         */
         RESTART = 2;
-        // Terminate all tasks including the executor itself. There's no way back for a terminated node.
+        /**
+         * Terminate all tasks including the executor itself. There's no way back for a terminated node.
+         */
         TERMINATE = 3;
     }
 
-    // The configuration files of this node need to be updated, but the Cassandra server process does not
-    // need to be restarted.
+    /**
+     * The configuration files of this node need to be updated, but the Cassandra server process does not
+     * need to be restarted.
+     */
     optional bool needsConfigUpdate = 14;
 }
 /**
@@ -828,15 +847,25 @@ message SlaveErrorDetails {
     optional int32 processExitCode = 4;
 
     enum ErrorType {
-        // cassandra server process is not runnning but is expected to be
+        /**
+         * cassandra server process is not runnning but is expected to be
+         */
         PROCESS_NOT_RUNNING = 1;
-        // cassandra server process exited
+        /**
+         * cassandra server process exited
+         */
         PROCESS_EXITED = 2;
-        // protobuf (de)serialization failed
+        /**
+         * protobuf (de)serialization failed
+         */
         PROTOCOL_VIOLATION = 3;
-        // another node job is still running
+        /**
+         * another node job is still running
+         */
         ANOTHER_JOB_RUNNING = 4;
-        // failed to start task
+        /**
+         * failed to start task
+         */
         TASK_START_FAILURE = 5;
     }
 }

--- a/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/ApiController.java
+++ b/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/ApiController.java
@@ -136,7 +136,7 @@ public final class ApiController {
      * "frameworkName" : "cassandra",
      * "frameworkId" : "20150318-143436-16777343-5050-5621-0000",
      * "defaultConfigRole" : {
-     *     "cassandraVersion" : "2.1.2",
+     *     "cassandraVersion" : "2.1.4",
      *     "targetNodeCount" : 2,
      *     "seedNodeCount" : 1,
      *     "diskMb" : 2048,
@@ -245,7 +245,7 @@ public final class ApiController {
      *     "healthCheckDetails" : {
      *         "healthy" : true,
      *         "msg" : "",
-     *         "version" : "2.1.2",
+     *         "version" : "2.1.4",
      *         "operationMode" : "NORMAL",
      *         "clusterName" : "cassandra",
      *         "dataCenter" : "DC1",
@@ -286,7 +286,7 @@ public final class ApiController {
      *     "healthCheckDetails" : {
      *         "healthy" : true,
      *         "msg" : "",
-     *         "version" : "2.1.2",
+     *         "version" : "2.1.4",
      *         "operationMode" : "JOINING",
      *         "clusterName" : "cassandra",
      *         "dataCenter" : "",

--- a/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/PersistedCassandraFrameworkConfiguration.java
+++ b/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/PersistedCassandraFrameworkConfiguration.java
@@ -39,7 +39,9 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
         final int executorCount,
         final int seedCount,
         final String mesosRole,
-        final String dataDirectory
+        final String dataDirectory,
+        final boolean jmxLocal,
+        final boolean jmxNoAuthentication
     ) {
         super(
             "CassandraFrameworkConfiguration",
@@ -56,7 +58,14 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
                         .setNumberOfNodes(executorCount)
                         .setNumberOfSeeds(seedCount)
                         .setMesosRole(mesosRole)
-                        .setPreDefinedDataDirectory(dataDirectory);
+                        .setPreDefinedDataDirectory(dataDirectory)
+                        .setTaskEnv(CassandraFrameworkProtos.TaskEnv.newBuilder()
+                            .addVariables(CassandraFrameworkProtos.TaskEnv.Entry.newBuilder()
+                                .setName("LOCAL_JMX")
+                                .setValue(jmxLocal ? "yes" : "no"))
+                            .addVariables(CassandraFrameworkProtos.TaskEnv.Entry.newBuilder()
+                                .setName("CASSANDRA_JMX_NO_AUTHENTICATION")
+                                .setValue(jmxNoAuthentication ? "yes" : "no")));
                     if (javeHeapMb > 0) {
                         configRole.setMemJavaHeapMb(javeHeapMb);
                     }

--- a/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/files/FileResourceController.java
+++ b/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/files/FileResourceController.java
@@ -33,7 +33,7 @@ public final class FileResourceController {
     @NotNull
     private final File cassandraTarFile;
 
-    public FileResourceController() {
+    public FileResourceController(String cassandraVersion) {
         File f;
 
         String javaVersion = Env.option("JAVA_VERSION").or("7u76");
@@ -46,7 +46,6 @@ public final class FileResourceController {
         verifyFileExistsAndCanRead(f);
         jreTarFile = f;
 
-        String cassandraVersion = Env.option("CASSANDRA_VERSION").or("2.1.4");
         String providedCassandraTar = Env.option("CASSANDRA_FILE_PATH").or(workingDir("/apache-cassandra-" + cassandraVersion + "-bin.tar.gz"));
         //f = null;
         //if (providedCassandraTar != null)

--- a/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/files/FileResourceController.java
+++ b/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/files/FileResourceController.java
@@ -46,7 +46,7 @@ public final class FileResourceController {
         verifyFileExistsAndCanRead(f);
         jreTarFile = f;
 
-        String cassandraVersion = Env.option("CASSANDRA_VERSION").or("2.1.2");
+        String cassandraVersion = Env.option("CASSANDRA_VERSION").or("2.1.4");
         String providedCassandraTar = Env.option("CASSANDRA_FILE_PATH").or(workingDir("/apache-cassandra-" + cassandraVersion + "-bin.tar.gz"));
         //f = null;
         //if (providedCassandraTar != null)

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/AbstractSchedulerTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/AbstractSchedulerTest.java
@@ -52,7 +52,7 @@ public abstract class AbstractSchedulerTest {
                 "test-cluster",
                 0, // health-check
                 0, // bootstrap-grace-time
-                "2.1.2",
+                "2.1.4",
             2, 4096, 4096, 0,
             3, 2,
             "*",
@@ -119,7 +119,7 @@ public abstract class AbstractSchedulerTest {
                         .setJoined(joined)
                         .setOperationMode(operationMode)
                         .setUptimeMillis(1234)
-                        .setVersion("2.1.2")
+                        .setVersion("2.1.4")
                         .setNativeTransportRunning(true)
                         .setRpcServerRunning(true)
                 )

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/AbstractSchedulerTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/AbstractSchedulerTest.java
@@ -14,7 +14,6 @@
 package io.mesosphere.mesos.frameworks.cassandra.scheduler;
 
 import io.mesosphere.mesos.frameworks.cassandra.CassandraFrameworkProtos;
-import io.mesosphere.mesos.frameworks.cassandra.scheduler.*;
 import io.mesosphere.mesos.util.SystemClock;
 import io.mesosphere.mesos.util.Tuple2;
 import org.apache.mesos.Protos;
@@ -56,7 +55,9 @@ public abstract class AbstractSchedulerTest {
             2, 4096, 4096, 0,
             3, 2,
             "*",
-            ".");
+            ".",
+            true,
+            false);
 
         cluster = new CassandraCluster(new SystemClock(),
                 "http://127.0.0.1:65535",

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/ApiControllerTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/ApiControllerTest.java
@@ -349,8 +349,6 @@ public class ApiControllerTest extends AbstractCassandraSchedulerTest {
         assertEquals(200, tup._1.intValue());
         JsonNode json = tup._2;
 
-        assertTrue(json.get("jmxPort").isNumber());
-
         for (int i = 0; i < activeNodes; i++) {
             Tuple2<Protos.SlaveID, String> slave = slaves[i];
             JsonNode node = json.get("nodes").get(executorMetadata[i].getExecutor().getExecutorId().getValue());
@@ -358,6 +356,7 @@ public class ApiControllerTest extends AbstractCassandraSchedulerTest {
             assertTrue(node.has("workdir"));
             assertTrue(node.has("hostname"));
             assertTrue(node.has("targetRunState"));
+            assertTrue(node.has("jmxIp"));
             assertTrue(node.has("jmxPort"));
             assertTrue(node.has("live"));
             assertTrue(node.get("logfiles").isArray());
@@ -373,11 +372,12 @@ public class ApiControllerTest extends AbstractCassandraSchedulerTest {
         assertEquals(200, tup._1.intValue());
 
         try (BufferedReader br = new BufferedReader(new StringReader(tup._2))) {
-            assertTrue(br.readLine().startsWith("JMX: "));
 
             for (int i = 0; i < activeNodes; i++) {
                 Tuple2<Protos.SlaveID, String> slave = slaves[i];
-                assertEquals("IP: " + slave._2, br.readLine());
+                assertThat(br.readLine()).startsWith("JMX_PORT: ");
+                assertEquals("JMX_IP: 127.0.0.1", br.readLine());
+                assertEquals("NODE_IP: " + slave._2, br.readLine());
                 assertEquals("BASE: http://" + slave._2 + ":5051/", br.readLine());
                 assertTrue(br.readLine().startsWith("LOG: "));
                 assertTrue(br.readLine().startsWith("LOG: "));

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraSchedulerTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraSchedulerTest.java
@@ -270,13 +270,13 @@ public class CassandraSchedulerTest extends AbstractCassandraSchedulerTest {
             .hasSize(2)
             .contains(
                 "/foo/executor.log",
-                "/foo/apache-cassandra-2.1.2/logs/system.log");
+                "/foo/apache-cassandra-2.1.4/logs/system.log");
 
         assertThat(cluster.getNodeLogFiles(node2))
             .hasSize(2)
             .contains(
                 "/bar/executor.log",
-                "/bar/apache-cassandra-2.1.2/logs/system.log");
+                "/bar/apache-cassandra-2.1.4/logs/system.log");
     }
 
     @Test

--- a/driver-extensions/shell-scripts/bin/com-cqlsh
+++ b/driver-extensions/shell-scripts/bin/com-cqlsh
@@ -3,6 +3,5 @@
 _BINARY=bin/cqlsh
 _LIVE_NODES_TYPE=cqlsh
 . `dirname $0`/com.in.sh
-#exec `dirname $0`/com_bin bin/cqlsh cqlsh "$@"
 
 exec ${EXEC} ${ARGS} "$@"

--- a/driver-extensions/shell-scripts/bin/com-nodetool
+++ b/driver-extensions/shell-scripts/bin/com-nodetool
@@ -3,6 +3,5 @@
 _BINARY=bin/nodetool
 _LIVE_NODES_TYPE=nodetool
 . `dirname $0`/com.in.sh
-#exec `dirname $0`/com_bin bin/nodetool nodetool "$@"
 
 exec ${EXEC} ${ARGS} "$@"

--- a/driver-extensions/shell-scripts/bin/com-qa-report
+++ b/driver-extensions/shell-scripts/bin/com-qa-report
@@ -26,10 +26,10 @@ function nodetoolInvoke() {
 
 curl -s "${API_BASE_URI}qaReportResources/text" | while read ln ; do
     case $ln in
-        JMX:*)
+        JMX_PORT:*)
             jmxPort="`echo $ln | cut -d\  -f 2`"
             ;;
-        IP:*)
+        NODE_IP:*)
             currentIp="`echo $ln | cut -d\  -f 2`"
             mkdir -p ${targetDir}/${currentIp}
 

--- a/package.bash
+++ b/package.bash
@@ -3,8 +3,9 @@ set -o errexit -o nounset -o pipefail
 
 PROJECT_DIR=$(pwd)
 TARGET_DIR="cassandra-mesos-dist/target/tarball"
+CASSANDRA_VERSION="2.1.4"
 
-DOWNLOAD_URL_CASS="https://downloads.mesosphere.io/cassandra-mesos/cassandra/apache-cassandra-2.1.4-bin.tar.gz"
+DOWNLOAD_URL_CASS="https://downloads.mesosphere.io/cassandra-mesos/cassandra/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
 
 VERSION=${VERSION:-"dev"}
 CLEAN_VERSION=${VERSION//\//_}
@@ -26,10 +27,10 @@ function clean {(
 
 function download {(
 
-    if [ ! -f "${TARGET_DIR}/apache-cassandra-2.1.4-bin.tar.gz" ] ; then
+    if [ ! -f "${TARGET_DIR}/apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz" ] ; then
         mkdir -p ${TARGET_DIR}
         cd ${TARGET_DIR}
-        _download ${DOWNLOAD_URL_CASS} "apache-cassandra-2.1.4-bin.tar.gz"
+        _download ${DOWNLOAD_URL_CASS} "apache-cassandra-${CASSANDRA_VERSION}-bin.tar.gz"
     fi
 
 )}

--- a/package.bash
+++ b/package.bash
@@ -4,7 +4,7 @@ set -o errexit -o nounset -o pipefail
 PROJECT_DIR=$(pwd)
 TARGET_DIR="cassandra-mesos-dist/target/tarball"
 
-DOWNLOAD_URL_CASS="https://downloads.mesosphere.io/cassandra-mesos/cassandra/apache-cassandra-2.1.2-bin.tar.gz"
+DOWNLOAD_URL_CASS="https://downloads.mesosphere.io/cassandra-mesos/cassandra/apache-cassandra-2.1.4-bin.tar.gz"
 
 VERSION=${VERSION:-"dev"}
 CLEAN_VERSION=${VERSION//\//_}
@@ -26,10 +26,10 @@ function clean {(
 
 function download {(
 
-    if [ ! -f "${TARGET_DIR}/apache-cassandra-2.1.2-bin.tar.gz" ] ; then
+    if [ ! -f "${TARGET_DIR}/apache-cassandra-2.1.4-bin.tar.gz" ] ; then
         mkdir -p ${TARGET_DIR}
         cd ${TARGET_DIR}
-        _download ${DOWNLOAD_URL_CASS} "apache-cassandra-2.1.2-bin.tar.gz"
+        _download ${DOWNLOAD_URL_CASS} "apache-cassandra-2.1.4-bin.tar.gz"
     fi
 
 )}

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.slf4j>1.7.10</version.slf4j>
         <version.joda>2.7</version.joda>
         <version.grizzly>2.16</version.grizzly>
-        <version.cassandra>2.1.2</version.cassandra>
+        <version.cassandra>2.1.4</version.cassandra>
 
         <version.grizzly>2.16</version.grizzly>
         <version.jackson>2.3.2</version.jackson> <!-- jackson is also transitively provided by grizzly! -->


### PR DESCRIPTION
Based on PR #80 

* Update C* version to 2.1.4
* By default there's no workaround for the CVE fixed in 2.1.4
* The readme expicitly documents the caveats (nodetool does not work remotely and com-qa-resources has limited functionality)
* readme describes how to workaround CVE (and let JMX listen to all addresses and skip authentication) and revert to the pre-2.1.4 insecure functionality

Additional:
Two minor doc updates