### PR TITLE
Only repair primary range

### DIFF
--- a/cassandra-mesos-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/executor/jmx/NodeRepairJob.java
+++ b/cassandra-mesos-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/executor/jmx/NodeRepairJob.java
@@ -66,8 +66,8 @@ public class NodeRepairJob extends AbstractNodeJob implements NotificationListen
 
             LOGGER.info("Starting repair on keyspace {}", keyspace);
 
-            // equivalent to 'nodetool repair' WITHOUT --partitioner-range, --full, --in-local-dc, --sequential
-            final int commandNo = checkNotNull(jmxConnect).getStorageServiceProxy().forceRepairAsync(keyspace, false, false, false, false);
+            // do 'nodetool repair' in local-DC and on node's primary range
+            final int commandNo = checkNotNull(jmxConnect).getStorageServiceProxy().forceRepairAsync(keyspace, false, true, true, false);
             if (commandNo == 0) {
                 LOGGER.info("Nothing to repair for keyspace {}", keyspace);
                 continue;


### PR DESCRIPTION
It's only necessary to repair a node's primary range (which will 'propagate' to the replica nodes). That's sufficient since the cluster-job does the repair on all nodes.

Additionally only repair in the 'local DC' (currently irrelevant for C* on Mesos).