### PR TITLE
attribute2config

### DIFF
--- a/cassandra-mesos-model/src/main/java/io/mesosphere/mesos/util/CassandraFrameworkProtosUtils.java
+++ b/cassandra-mesos-model/src/main/java/io/mesosphere/mesos/util/CassandraFrameworkProtosUtils.java
@@ -188,7 +188,8 @@ public final class CassandraFrameworkProtosUtils {
         return ResourceToPortSet.INSTANCE;
     }
 
-    public static Predicate<Resource> containsPort(@NotNull long port) {
+    @NotNull
+    public static Predicate<Resource> containsPort(long port) {
         return new ContainsPort(port);
     }
 
@@ -242,6 +243,16 @@ public final class CassandraFrameworkProtosUtils {
         } else {
             return "*";
         }
+    }
+
+    public static String attributeValue(@NotNull final Protos.Offer offer, @NotNull final String name) {
+        for (final Protos.Attribute attribute : offer.getAttributesList()) {
+            if (name.equals(attribute.getName())) {
+                return attribute.hasText() ? attribute.getText().getValue() : null;
+            }
+        }
+
+        return null;
     }
 
     public static Function<Map.Entry<String, Collection<Long>>, Resource> roleAndPortsToResource() {

--- a/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraCluster.java
+++ b/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraCluster.java
@@ -84,6 +84,9 @@ public final class CassandraCluster {
     public static final String PORT_RPC = "rpc_port";
     public static final String PORT_JMX = "jmx_port";
 
+    public static final String RACK_ATTRIBUTE = "CASSANDRA_RACK";
+    public static final String DC_ATTRIBUTE = "CASSANDRA_DC";
+
     // see: http://www.datastax.com/documentation/cassandra/2.1/cassandra/security/secureFireWall_r.html
     private static final Map<String, Long> defaultPortMappings = unmodifiableHashMap(
         tuple2(PORT_STORAGE, 7000L),
@@ -422,7 +425,7 @@ public final class CassandraCluster {
             builder.setReplacementForIp(replacementForIp);
         }
 
-        builder.setRackDc(configuration.getDefaultRackDc());
+        builder.setRackDc(getRackDc(offer));
 
         try {
             final InetAddress ia = InetAddress.getByName(offer.getHostname());
@@ -446,6 +449,18 @@ public final class CassandraCluster {
         } catch (final UnknownHostException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @NotNull
+    private RackDc getRackDc(@NotNull final Protos.Offer offer) {
+        final String rack = attributeValue(offer, RACK_ATTRIBUTE);
+        final String dc = attributeValue(offer, DC_ATTRIBUTE);
+
+        final RackDc.Builder builder = RackDc.newBuilder(configuration.getDefaultRackDc());
+        if (rack != null) builder.setRack(rack);
+        if (dc != null) builder.setDc(dc);
+
+        return builder.build();
     }
 
     private int getPortMapping(@NotNull final String name) {

--- a/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraCluster.java
+++ b/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraCluster.java
@@ -453,11 +453,12 @@ public final class CassandraCluster {
 
     @NotNull
     private RackDc getRackDc(@NotNull final Protos.Offer offer) {
-        final String rack = attributeValue(offer, RACK_ATTRIBUTE);
-        final String dc = attributeValue(offer, DC_ATTRIBUTE);
-
         final RackDc.Builder builder = RackDc.newBuilder(configuration.getDefaultRackDc());
+
+        // override default rack/dc with attribute values, if defined
+        final String rack = attributeValue(offer, RACK_ATTRIBUTE);
         if (rack != null) builder.setRack(rack);
+        final String dc = attributeValue(offer, DC_ATTRIBUTE);
         if (dc != null) builder.setDc(dc);
 
         return builder.build();


### PR DESCRIPTION
Hi,

I've added support of CASSANDRA_RACK, CASSANDRA_DC slave attributes. If those attributes are present in Offer, Scheduler uses their value as RACK/DC properties of CassandraNode.

Please review & merge.