### PR TITLE
Fix NPE when startup fails and 'process' is null

### DIFF
--- a/cassandra-mesos-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/executor/CassandraExecutor.java
+++ b/cassandra-mesos-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/executor/CassandraExecutor.java
@@ -160,7 +160,9 @@ public final class CassandraExecutor implements Executor {
                         serverTask = task;
                         jmxConnect = objectFactory.newJmxConnect(cassandraServerRunTask.getJmx());
                         startCheckingHealth(driver, jmxConnect, cassandraServerRunTask.getHealthCheckIntervalSeconds());
-                        if (process != null) {
+                        if (process == null) { 
+                            ExecutorUtils.serverProcessNotRunning(driver, task);
+                        } else {
                             driver.sendStatusUpdate(taskStatus(serverTask, TaskState.TASK_RUNNING,
                                 SlaveStatusDetails.newBuilder()
                                     .setStatusDetailsType(SlaveStatusDetails.StatusDetailsType.CASSANDRA_SERVER_RUN)

--- a/cassandra-mesos-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/executor/CassandraExecutor.java
+++ b/cassandra-mesos-executor/src/main/java/io/mesosphere/mesos/frameworks/cassandra/executor/CassandraExecutor.java
@@ -160,12 +160,14 @@ public final class CassandraExecutor implements Executor {
                         serverTask = task;
                         jmxConnect = objectFactory.newJmxConnect(cassandraServerRunTask.getJmx());
                         startCheckingHealth(driver, jmxConnect, cassandraServerRunTask.getHealthCheckIntervalSeconds());
-                        driver.sendStatusUpdate(taskStatus(serverTask, TaskState.TASK_RUNNING,
-                            SlaveStatusDetails.newBuilder()
-                                .setStatusDetailsType(SlaveStatusDetails.StatusDetailsType.CASSANDRA_SERVER_RUN)
-                                .setCassandraServerRunMetadata(CassandraServerRunMetadata.newBuilder()
-                                    .setPid(process.getPid()))
-                                .build()));
+                        if (process != null) {
+                            driver.sendStatusUpdate(taskStatus(serverTask, TaskState.TASK_RUNNING,
+                                SlaveStatusDetails.newBuilder()
+                                    .setStatusDetailsType(SlaveStatusDetails.StatusDetailsType.CASSANDRA_SERVER_RUN)
+                                    .setCassandraServerRunMetadata(CassandraServerRunMetadata.newBuilder()
+                                        .setPid(process.getPid()))
+                                    .build()));
+                        }
                     } catch (final LaunchNodeException e) {
                         LOGGER.error(taskIdMarker, "Failed to start Cassandra daemon", e);
                         driver.sendStatusUpdate(ExecutorUtils.slaveErrorDetails(task, "Failed to start Cassandra daemon", e.toString(), SlaveErrorDetails.ErrorType.PROCESS_NOT_RUNNING));


### PR DESCRIPTION
This failure case results in emitting a TASK_ERROR status update at L155, so it looks like we should skip the TASK_RUNNING message entirely in this case? Alternate option could be to send the message, but with a different or unset value for the PID.
