### PR TITLE
Speeding up the cluster start up

### DIFF
--- a/cassandra-mesos-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/framework/Main.java
+++ b/cassandra-mesos-framework/src/main/java/io/mesosphere/mesos/frameworks/cassandra/framework/Main.java
@@ -134,7 +134,6 @@ public final class Main {
         final long      resourceDiskMegabytes       = Long.parseLong(       Env.option("CASSANDRA_RESOURCE_DISK_MB").or("2048"));
         final long      javaHeapMb                  = Long.parseLong(       Env.option("CASSANDRA_RESOURCE_HEAP_MB").or("0"));
         final long      healthCheckIntervalSec      = Long.parseLong(       Env.option("CASSANDRA_HEALTH_CHECK_INTERVAL_SECONDS").or("60"));
-        final long      bootstrapGraceTimeSec       = Long.parseLong(       Env.option("CASSANDRA_BOOTSTRAP_GRACE_TIME_SECONDS").or("120"));
         final String    cassandraVersion            =                       "2.1.4";
         final String    clusterName                 =                       clusterNameOpt.or("cassandra");
         final String    frameworkName               =                       frameworkName(clusterNameOpt);
@@ -169,7 +168,6 @@ public final class Main {
             state,
             frameworkName,
             healthCheckIntervalSec,
-            bootstrapGraceTimeSec,
             cassandraVersion,
             resourceCpuCores,
             resourceDiskMegabytes,

--- a/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
+++ b/cassandra-mesos-model/src/main/proto/io/mesosphere/mesos/frameworks/cassandra/model.proto
@@ -41,10 +41,6 @@ message CassandraFrameworkConfiguration {
      */
     optional int64 healthCheckIntervalSeconds = 3;
     /**
-     * Minimum interval in seconds between two starts of a Cassandra server task (= Cassandra process).
-     */
-    optional int64 bootstrapGraceTimeSeconds = 4;
-    /**
      * Globally shared mapping of ports required by Cassandra.
      * Currently there are port mappings for these kinds of ports and respective default values:
      * storage_port=7000, ssl_storage_port=7001, native_transport_port=9042, rpc_port=9160, jmx_port=7199

--- a/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraCluster.java
+++ b/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraCluster.java
@@ -1331,16 +1331,6 @@ public final class CassandraCluster {
     }
 
     @VisibleForTesting
-    static long nextPossibleServerLaunchTimestamp(
-        final long lastServerLaunchTimestamp,
-        final long bootstrapGraceTimeSeconds,
-        final long healthCheckIntervalSeconds
-    ) {
-        final long seconds = Math.max(bootstrapGraceTimeSeconds, healthCheckIntervalSeconds);
-        return lastServerLaunchTimestamp + seconds * 1000L;
-    }
-
-    @VisibleForTesting
     boolean ableToLaunchServerTask(@NotNull final Marker marker, final long now) {
         final long healthCheckEndThreshold = now - 5L * configuration.healthCheckInterval().getMillis();
         for (final CassandraNode cassandraNode : clusterState.nodes()) {

--- a/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraCluster.java
+++ b/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraCluster.java
@@ -389,14 +389,6 @@ public final class CassandraCluster {
         return executorTaskId(node) + ".server";
     }
 
-    public long nextPossibleServerLaunchTimestamp() {
-        return nextPossibleServerLaunchTimestamp(
-            getClusterState().get().getLastServerLaunchTimestamp(),
-            getConfiguration().get().getBootstrapGraceTimeSeconds(),
-            getConfiguration().get().getHealthCheckIntervalSeconds()
-        );
-    }
-
     @NotNull
     public Optional<CassandraNode> cassandraNodeForHostname(@NotNull final String hostname) {
         return headOption(
@@ -1385,17 +1377,4 @@ public final class CassandraCluster {
         return true;
     }
 
-    @VisibleForTesting
-    static boolean canLaunchServerTask(final long now, final long nextPossibleServerLaunchTimestamp) {
-        return now >= nextPossibleServerLaunchTimestamp;
-    }
-
-    @VisibleForTesting
-    static long secondsUntilNextPossibleServerLaunch(final long now, final long nextPossibleServerLaunchTimestamp) {
-        final long millisUntilNext = nextPossibleServerLaunchTimestamp - now;
-        if (millisUntilNext <= 0) {
-            return 0L;
-        }
-        return millisUntilNext / 1000;
-    }
 }

--- a/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/PersistedCassandraFrameworkConfiguration.java
+++ b/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/PersistedCassandraFrameworkConfiguration.java
@@ -35,7 +35,6 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
         @NotNull final State state,
         @NotNull final String frameworkName,
         final long healthCheckIntervalSeconds,
-        final long bootstrapGraceTimeSec,
         @NotNull final String cassandraVersion,
         final double cpuCores,
         final long diskMb,
@@ -83,7 +82,6 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
                         .setFrameworkName(frameworkName)
                         .setDefaultConfigRole(fillConfigRoleGaps(configRole))
                         .setHealthCheckIntervalSeconds(healthCheckIntervalSeconds)
-                        .setBootstrapGraceTimeSeconds(bootstrapGraceTimeSec)
                         .setTargetNumberOfNodes(executorCount)
                         .setTargetNumberOfSeeds(seedCount)
                         .addAllExternalDcs(externalDcs)
@@ -181,19 +179,6 @@ public final class PersistedCassandraFrameworkConfiguration extends StatePersist
         setValue(
                 CassandraFrameworkConfiguration.newBuilder(get())
                         .setHealthCheckIntervalSeconds(interval.getStandardSeconds())
-                        .build()
-        );
-    }
-
-    @NotNull
-    public Duration bootstrapGraceTimeSeconds() {
-        return Duration.standardSeconds(get().getBootstrapGraceTimeSeconds());
-    }
-
-    public void bootstrapGraceTimeSeconds(@NotNull final Duration interval) {
-        setValue(
-                CassandraFrameworkConfiguration.newBuilder(get())
-                    .setBootstrapGraceTimeSeconds(interval.getStandardSeconds())
                         .build()
         );
     }

--- a/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/api/ConfigController.java
+++ b/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/api/ConfigController.java
@@ -67,7 +67,6 @@ public final class ConfigController {
      * "sslStoragePort" : 7001,
      * "seeds" : [ "127.0.0.1" ],
      * "healthCheckIntervalSeconds" : 10,
-     * "bootstrapGraceTimeSeconds" : 0,
      * "currentClusterTask" : null,
      * "lastRepair" : null,
      * "lastCleanup" : null
@@ -107,7 +106,6 @@ public final class ConfigController {
                 JaxRsUtils.writeSeedIps(cluster, json);
 
                 json.writeNumberField("healthCheckIntervalSeconds", config.getHealthCheckIntervalSeconds());
-                json.writeNumberField("bootstrapGraceTimeSeconds", config.getBootstrapGraceTimeSeconds());
 
                 final CassandraFrameworkProtos.ClusterJobStatus currentTask = cluster.getCurrentClusterJob();
                 JaxRsUtils.writeClusterJob(cluster, json, "currentClusterTask", currentTask);

--- a/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/api/ConfigController.java
+++ b/cassandra-mesos-scheduler/src/main/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/api/ConfigController.java
@@ -70,8 +70,7 @@ public final class ConfigController {
      * "bootstrapGraceTimeSeconds" : 0,
      * "currentClusterTask" : null,
      * "lastRepair" : null,
-     * "lastCleanup" : null,
-     * "nextPossibleServerLaunchTimestamp" : 1426685858805
+     * "lastCleanup" : null
      * }}</pre>
      */
     @GET
@@ -118,8 +117,6 @@ public final class ConfigController {
 
                 final CassandraFrameworkProtos.ClusterJobStatus lastCleanup = cluster.getLastClusterJob(CassandraFrameworkProtos.ClusterJobType.CLEANUP);
                 JaxRsUtils.writeClusterJob(cluster, json, "lastCleanup", lastCleanup);
-
-                json.writeNumberField("nextPossibleServerLaunchTimestamp", cluster.nextPossibleServerLaunchTimestamp());
 
             }
         });

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/AbstractCassandraSchedulerTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/AbstractCassandraSchedulerTest.java
@@ -955,13 +955,13 @@ public abstract class AbstractCassandraSchedulerTest extends AbstractSchedulerTe
         executorServer = new Tuple2[slaves.length];
 
         executorServer[0] = launchTask(slaves[0], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+        sendHealthCheckResult(executorMetadata[0], healthCheckDetailsSuccess("NORMAL", true));
         executorServer[1] = launchTask(slaves[1], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
+        sendHealthCheckResult(executorMetadata[1], healthCheckDetailsSuccess("NORMAL", true));
 
         executorTaskRunning(executorServer[0]._1);
         executorTaskRunning(executorServer[1]._1);
 
-        sendHealthCheckResult(executorMetadata[0], healthCheckDetailsSuccess("NORMAL", true));
-        sendHealthCheckResult(executorMetadata[1], healthCheckDetailsSuccess("NORMAL", true));
 
         executorServer[2] = launchTask(slaves[2], CassandraFrameworkProtos.TaskDetails.TaskDetailsType.CASSANDRA_SERVER_RUN);
 

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/AbstractSchedulerTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/AbstractSchedulerTest.java
@@ -54,7 +54,7 @@ public abstract class AbstractSchedulerTest {
         configuration = new PersistedCassandraFrameworkConfiguration(
                 state,
                 "test-cluster",
-                0, // health-check
+                15, // health-check
                 0, // bootstrap-grace-time
                 "2.1.4",
             2, 4096, 4096, 0,

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/AbstractSchedulerTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/AbstractSchedulerTest.java
@@ -55,7 +55,6 @@ public abstract class AbstractSchedulerTest {
                 state,
                 "test-cluster",
                 15, // health-check
-                0, // bootstrap-grace-time
                 "2.1.4",
             2, 4096, 4096, 0,
             3, 2,

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraClusterStateTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraClusterStateTest.java
@@ -94,6 +94,8 @@ public class CassandraClusterStateTest extends AbstractSchedulerTest {
         noopOnOffer(cluster, slaves[2], 3);
 
         launchServer(cluster, slaves[0]);
+        cluster.recordHealthCheck(executorMetadata1.getExecutorId(), healthCheckDetailsSuccess("NORMAL", true));
+
         launchServer(cluster, slaves[1]);
         // still - not able to start node #3
         noopOnOffer(cluster, slaves[2], 3);
@@ -138,6 +140,7 @@ public class CassandraClusterStateTest extends AbstractSchedulerTest {
         assertThat(lastHealthCheckDetails(executorMetadata2))
             .isNot(healthy());
         // node#3 can start now
+        cluster.recordHealthCheck(executorMetadata2.getExecutorId(), healthCheckDetailsSuccess("NORMAL", true));
         launchServer(cluster, slaves[2]);
 
     }
@@ -157,11 +160,12 @@ public class CassandraClusterStateTest extends AbstractSchedulerTest {
         cluster.addExecutorMetadata(executorMetadata3);
 
         // launch servers
-
         launchServer(cluster, slaves[0]);
-        launchServer(cluster, slaves[1]);
 
         cluster.recordHealthCheck(executorMetadata1.getExecutorId(), healthCheckDetailsSuccess("NORMAL", true));
+
+        launchServer(cluster, slaves[1]);
+
         cluster.recordHealthCheck(executorMetadata2.getExecutorId(), healthCheckDetailsSuccess("NORMAL", true));
 
         launchServer(cluster, slaves[2]);

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraClusterTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraClusterTest.java
@@ -23,62 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CassandraClusterTest {
 
     @Test
-    public void nextPossibleServerLaunchTimestamp() throws Exception {
-        assertThat(CassandraCluster.nextPossibleServerLaunchTimestamp(0, 60, 60)).isEqualTo(60_000L);
-        assertThat(CassandraCluster.nextPossibleServerLaunchTimestamp(9, 60, 60)).isEqualTo(60_009L);
-    }
-
-    @Test
-    public void nextPossibleServerLaunchTimestamp_healthCheckTimeoutIsUsedWhenGracePeriodIsSmaller() throws Exception {
-        assertThat(CassandraCluster.nextPossibleServerLaunchTimestamp(0, 15, 60)).isEqualTo(60_000L);
-    }
-
-    @Test
-    public void canLaunchServerTask_1() throws Exception {
-        assertThat(CassandraCluster.canLaunchServerTask(0, 10)).isFalse();
-    }
-
-    @Test
-    public void canLaunchServerTask_2() throws Exception {
-        assertThat(CassandraCluster.canLaunchServerTask(9, 10)).isFalse();
-    }
-
-    @Test
-    public void canLaunchServerTask_3() throws Exception {
-        assertThat(CassandraCluster.canLaunchServerTask(10, 10)).isTrue();
-    }
-
-    @Test
-    public void canLaunchServerTask_4() throws Exception {
-        assertThat(CassandraCluster.canLaunchServerTask(11, 10)).isTrue();
-    }
-
-    @Test
-    public void secondsUntilNextPossibleServerLaunch_1() throws Exception {
-        assertThat(CassandraCluster.secondsUntilNextPossibleServerLaunch(0, 10)).isEqualTo(0);
-    }
-
-    @Test
-    public void secondsUntilNextPossibleServerLaunch_2() throws Exception {
-        assertThat(CassandraCluster.secondsUntilNextPossibleServerLaunch(0, 10_000)).isEqualTo(10);
-    }
-
-    @Test
-    public void secondsUntilNextPossibleServerLaunch_3() throws Exception {
-        assertThat(CassandraCluster.secondsUntilNextPossibleServerLaunch(10_000, 10_000)).isEqualTo(0);
-    }
-
-    @Test
-    public void secondsUntilNextPossibleServerLaunch_4() throws Exception {
-        assertThat(CassandraCluster.secondsUntilNextPossibleServerLaunch(9_000, 10_000)).isEqualTo(1);
-    }
-
-    @Test
-    public void secondsUntilNextPossibleServerLaunch_5() throws Exception {
-        assertThat(CassandraCluster.secondsUntilNextPossibleServerLaunch(11_000, 10_000)).isEqualTo(0);
-    }
-
-    @Test
     public void removeExecutor_cleansAllTasksAndExecutorInfo() throws Exception {
         final InMemoryState state = new InMemoryState();
         final Clock clock = new SystemClock();

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraClusterTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraClusterTest.java
@@ -31,7 +31,7 @@ public class CassandraClusterTest {
         final PersistedCassandraClusterHealthCheckHistory healthCheckHistory = new PersistedCassandraClusterHealthCheckHistory(state);
         final PersistedCassandraClusterJobs jobsState = new PersistedCassandraClusterJobs(state);
         final PersistedCassandraFrameworkConfiguration configuration = new PersistedCassandraFrameworkConfiguration(
-            state, "cassandra.unit-test", 15, 15, "2.1.4", 1.0, 64, 64, 32, 1, 1, "*", "./backup", ".", true, false,
+            state, "cassandra.unit-test", 15, "2.1.4", 1.0, 64, 64, 32, 1, 1, "*", "./backup", ".", true, false,
             "rack0", "dc0", Collections.<CassandraFrameworkProtos.ExternalDc>emptyList(), "cassandra.unit-test"
         );
         final CassandraCluster cluster1 = new CassandraCluster(

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraSchedulerTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/CassandraSchedulerTest.java
@@ -152,7 +152,6 @@ public class CassandraSchedulerTest extends AbstractCassandraSchedulerTest {
                 .setResources(resources(1, 2048, 2048)))
             .setFrameworkName("a name")
             .setHealthCheckIntervalSeconds(10)
-            .setBootstrapGraceTimeSeconds(10)
             .build();
 
         try {
@@ -173,7 +172,6 @@ public class CassandraSchedulerTest extends AbstractCassandraSchedulerTest {
                 .setResources(resources(1, 2048, 2048)))
             .setFrameworkName("a name")
             .setHealthCheckIntervalSeconds(10)
-            .setBootstrapGraceTimeSeconds(10)
             .addPortMapping(CassandraFrameworkProtos.PortMapping.newBuilder()
                 .setName(CassandraCluster.PORT_JMX)
                 .setPort(1))

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/PersistedCassandraFrameworkConfigurationTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/PersistedCassandraFrameworkConfigurationTest.java
@@ -29,7 +29,6 @@ public class PersistedCassandraFrameworkConfigurationTest {
                 state,
                 "name",
                 60,
-                30,
                 "2.1",
                 0.5,
                 1024,
@@ -70,7 +69,6 @@ public class PersistedCassandraFrameworkConfigurationTest {
             state,
             "frameworkName should be cassandra.cluster not this value",
             15,
-            15,
             "2.1.4",
             1.0,
             2048,
@@ -100,7 +98,6 @@ public class PersistedCassandraFrameworkConfigurationTest {
         final PersistedCassandraFrameworkConfiguration configuration = new PersistedCassandraFrameworkConfiguration(
             state,
             "cassandra.frameworkName",
-            15,
             15,
             "2.1.4",
             1.0,

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/SeedManagerTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/SeedManagerTest.java
@@ -32,7 +32,6 @@ public class SeedManagerTest {
                 state,
                 "name",
                 60,
-                30,
                 "2.1",
                 0.5,
                 1024,

--- a/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/health/HealthReportServiceTest.java
+++ b/cassandra-mesos-scheduler/src/test/java/io/mesosphere/mesos/frameworks/cassandra/scheduler/health/HealthReportServiceTest.java
@@ -182,7 +182,6 @@ public class HealthReportServiceTest {
             CassandraFrameworkConfiguration.newBuilder()
                 .setFrameworkName("cassandra.testing")
                 .setHealthCheckIntervalSeconds(60)
-                .setBootstrapGraceTimeSeconds(120)
                 .setTargetNumberOfNodes(numberOfNodes)
                 .setTargetNumberOfSeeds(numberOfSeeds);
 
@@ -659,7 +658,6 @@ public class HealthReportServiceTest {
             CassandraFrameworkConfiguration.newBuilder()
                 .setFrameworkName("cassandra.testing")
                 .setHealthCheckIntervalSeconds(60)
-                .setBootstrapGraceTimeSeconds(120)
                 .setTargetNumberOfNodes(numberOfNodes)
                 .setTargetNumberOfSeeds(numberOfSeeds);
 
@@ -806,7 +804,6 @@ public class HealthReportServiceTest {
             CassandraFrameworkConfiguration.newBuilder()
                 .setFrameworkName("cassandra.testing")
                 .setHealthCheckIntervalSeconds(60)
-                .setBootstrapGraceTimeSeconds(120)
                 .setTargetNumberOfNodes(numberOfNodes)
                 .setTargetNumberOfSeeds(numberOfSeeds);
 
@@ -992,7 +989,6 @@ public class HealthReportServiceTest {
             CassandraFrameworkConfiguration.newBuilder()
                 .setFrameworkName("cassandra.testing")
                 .setHealthCheckIntervalSeconds(60)
-                .setBootstrapGraceTimeSeconds(120)
                 .setTargetNumberOfNodes(numberOfNodes)
                 .setTargetNumberOfSeeds(numberOfSeeds);
 


### PR DESCRIPTION
Hey,

Motivation:

Current cassandra-mesos master branch delays next server task start
by predefined interval (for instance 2 minutes through
CASSANDRA_BOOTSTRAP_GRACE_TIME_SECONDS), this delay could be
minimized.  Spin up cluster faster by allowing to start next server
task only when all other Cassandra nodes joined to cluster and
operate normally.

Modification:

Changes for CassandraScheduler, implemented ableToLaunchServerTask,
to replace call to canLaunchServerTask, that will
return true when all CassandraNode nodes, that have server task and target
state is run, have latest health check that satisfies
CassandraCluster.isNodeHealthyJoinedAndOperatingNormally
otherwise don't allow to start next server task (return false). 

No changes for CassandraExecutor.

CASSANDRA_HEALTH_CHECK_INTERVAL_SECONDS has to be set to 
small value like 15 - 25 seconds in order to get health checks often.

Possible improvements that could be made for CassandraExecutor is
when starting cassandra server spin up additional thread
that will poll Cassandra status through JMX and once its
up and operation normally sendStatusUpdate containing
health check details. After then stop checking. Default
health checking thread will remain active. Difference
between additional and default health checking thread:
- additional thread has small health check interval (like 15 seconds) while
  default thread uses interval specified through env variable CASSANDRA_HEALTH_CHECK_INTERVAL_SECONDS
- additional thread will send health check via sendStatusUpdate, 
  where as default thread will send updates via sendFrameworkMessage
- additional thread will stop polling once node join to cluster and operation normally

Result:
Faster startup time of cluster, almost by half time it used to be (depending on CASSANDRA_BOOTSTRAP_GRACE_TIME_SECONDS and CASSANDRA_HEALTH_CHECK_INTERVAL_SECONDS).
